### PR TITLE
Support subscriber URL base in configuration

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -19,6 +19,7 @@ This document describes the minimal specifications for the project.  It is meant
 The three services (broker, publisher and subscriber) have a number of common options:
 
 - `--http`: the hostname and port that it listens, e.g. `localhost:8000`
+- `--url`: the base of public URLs provided by the subscriber, if different from `http://<HTTP_HOST>:<HTTP_PORT>/` (only for subscriber)
 - `--loglevel`: by default `warning`
 - `--statedir`: directory where to store the service state files (cache, logs, pid file, etc.)
 - `--broker`: the hostname and port where the broker runs (only for publisher and subscriber)
@@ -57,6 +58,7 @@ root = "root-examples"
 
 [subscriber.1]
 http = "localhost:8002"
+url = "https://cat2.example.com/"  # e.g. served by reverse proxy
 statedir = "_caterva2/sub"
 loglevel = "warning"
 ```

--- a/SPECS.md
+++ b/SPECS.md
@@ -19,7 +19,7 @@ This document describes the minimal specifications for the project.  It is meant
 The three services (broker, publisher and subscriber) have a number of common options:
 
 - `--http`: the hostname and port that it listens, e.g. `localhost:8000`
-- `--url`: the base of public URLs provided by the subscriber, if different from `http://<HTTP_HOST>:<HTTP_PORT>/` (only for subscriber)
+- `--url`: the base of URLs provided by the subscriber, if different from `http://<HTTP_HOST>:<HTTP_PORT>/` (only for subscriber)
 - `--loglevel`: by default `warning`
 - `--statedir`: directory where to store the service state files (cache, logs, pid file, etc.)
 - `--broker`: the hostname and port where the broker runs (only for publisher and subscriber)

--- a/caterva2.sample.toml
+++ b/caterva2.sample.toml
@@ -38,7 +38,7 @@ http = "localhost:8001"
 # Several of these are allowed, each with a different ID (the string after the dot). A subscriber invoked with ``--id=something`` will look its configuration up in the ``subscriber.something`` section.
 [subscriber.1]
 http = "localhost:8002"  # The ``host:port`` endpoint where the service listens for HTTP requests. Use ``*`` as a host to listen on all addresses.
-url = "https://cat2.example.com/"  # The base of public URLs, if different from ``http://<subscriber.http>/``.
+url = "https://cat2.example.com/"  # The base of URLs, if different from ``http://<subscriber.http>/``.
 statedir = "_caterva2/sub"  # The directory where the service will place state files.
 loglevel = "warning"  # All service messages having this severity or worse will be logged.
 

--- a/caterva2.sample.toml
+++ b/caterva2.sample.toml
@@ -38,12 +38,13 @@ http = "localhost:8001"
 # Several of these are allowed, each with a different ID (the string after the dot). A subscriber invoked with ``--id=something`` will look its configuration up in the ``subscriber.something`` section.
 [subscriber.1]
 http = "localhost:8002"  # The ``host:port`` endpoint where the service listens for HTTP requests. Use ``*`` as a host to listen on all addresses.
+url = "https://cat2.example.com/"  # The base of public URLs, if different from ``http://<subscriber.http>/``.
 statedir = "_caterva2/sub"  # The directory where the service will place state files.
 loglevel = "warning"  # All service messages having this severity or worse will be logged.
 
-# Only one of these is allowed. It will be used by a subscriber invoked with no ID, or it may be used by other programs to find how to connect to a subscriber (``subscriber.http``).
+# Only one of these is allowed. It will be used by a subscriber invoked with no ID, or it may be used by other programs to find how to connect to a subscriber (``subscriber.url``).
 [subscriber]
-http = "localhost:8001"
+url = "https://cat2.example.com/"
 # ... other settings as above ...
 
 # Common configuration of client programs.

--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -13,6 +13,6 @@ __version__ = "0.2.1.dev0"
 """The version in use of the Caterva2 package."""
 
 from .api import (bro_host_default, pub_host_default, sub_host_default,
-                  sub_base_default)
+                  sub_url_default)
 from .api import get_roots, subscribe, get_list, get_info, fetch, download
 from .api import Root, File, Dataset

--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -12,6 +12,7 @@
 __version__ = "0.2.1.dev0"
 """The version in use of the Caterva2 package."""
 
-from .api import bro_host_default, pub_host_default, sub_host_default
+from .api import (bro_host_default, pub_host_default, sub_host_default,
+                  sub_base_default)
 from .api import get_roots, subscribe, get_list, get_info, fetch, download
 from .api import Root, File, Dataset

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -38,7 +38,7 @@ def get_roots(sub_url=sub_url_default, auth_cookie=None):
     ----------
 
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -60,7 +60,7 @@ def subscribe(root, sub_url=sub_url_default, auth_cookie=None):
     root : str
         The name of the root to subscribe to.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -82,7 +82,7 @@ def get_list(root, sub_url=sub_url_default, auth_cookie=None):
     root : str
         The name of the root to list.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -104,7 +104,7 @@ def get_info(dataset, sub_url=sub_url_default, auth_cookie=None):
     dataset : str
         The name of the dataset.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -127,7 +127,7 @@ def fetch(dataset, sub_url=sub_url_default, slice_=None, prefer_schunk=True,
     dataset : str
         The name of the dataset.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     slice_ : str
         The slice to fetch.
     prefer_schunk : bool
@@ -159,7 +159,7 @@ def download(dataset, sub_url=sub_url_default, auth_cookie=None):
     dataset : str
         The name of the dataset.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -226,7 +226,7 @@ class File:
     root : str
         The name of the root.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
 
@@ -391,7 +391,7 @@ class Dataset(File):
     root : str
         The name of the root.
     sub_url : str
-        The base URL of the subscriber to query.
+        The base URL (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
 

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -186,6 +186,8 @@ class Root:
     """
     def __init__(self, name, sub_base=sub_base_default, user_auth=None):
         self.name = name
+        if not sub_base.endswith('/'):
+            sub_base += '/'
         self.sub_base = sub_base
         self.auth_cookie = (
             api_utils.get_auth_cookie(sub_base, user_auth)

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -13,7 +13,7 @@ This module provides a Python API to Caterva2.
 import functools
 import pathlib
 
-from caterva2 import api_utils
+from caterva2 import api_utils, utils
 
 
 # Defaults
@@ -186,9 +186,7 @@ class Root:
     """
     def __init__(self, name, sub_base=sub_base_default, user_auth=None):
         self.name = name
-        if not sub_base.endswith('/'):
-            sub_base += '/'
-        self.sub_base = sub_base
+        self.sub_base = utils.urlbase_type(sub_base)
         self.auth_cookie = (
             api_utils.get_auth_cookie(sub_base, user_auth)
             if user_auth else None)

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -26,6 +26,9 @@ pub_host_default = 'localhost:8001'
 sub_host_default = 'localhost:8002'
 """The default HTTP endpoint for the subscriber (URL host & port)."""
 
+sub_base_default = f'http://{sub_host_default}/'
+"""The default base for URLs provided by the subscriber (slash-terminated)."""
+
 
 def get_roots(host=sub_host_default, auth_cookie=None):
     """

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -26,18 +26,18 @@ pub_host_default = 'localhost:8001'
 sub_host_default = 'localhost:8002'
 """The default HTTP endpoint for the subscriber (URL host & port)."""
 
-sub_base_default = f'http://{sub_host_default}/'
+sub_url_default = f'http://{sub_host_default}/'
 """The default base for URLs provided by the subscriber (slash-terminated)."""
 
 
-def get_roots(sub_base=sub_base_default, auth_cookie=None):
+def get_roots(sub_url=sub_url_default, auth_cookie=None):
     """
     Get the list of available roots.
 
     Parameters
     ----------
 
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -48,10 +48,10 @@ def get_roots(sub_base=sub_base_default, auth_cookie=None):
         The list of available roots.
 
     """
-    return api_utils.get(f'{sub_base}api/roots', auth_cookie=auth_cookie)
+    return api_utils.get(f'{sub_url}api/roots', auth_cookie=auth_cookie)
 
 
-def subscribe(root, sub_base=sub_base_default, auth_cookie=None):
+def subscribe(root, sub_url=sub_url_default, auth_cookie=None):
     """
     Subscribe to a root.
 
@@ -59,7 +59,7 @@ def subscribe(root, sub_base=sub_base_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to subscribe to.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -69,11 +69,11 @@ def subscribe(root, sub_base=sub_base_default, auth_cookie=None):
     str
         The response from the server.
     """
-    return api_utils.post(f'{sub_base}api/subscribe/{root}',
+    return api_utils.post(f'{sub_url}api/subscribe/{root}',
                           auth_cookie=auth_cookie)
 
 
-def get_list(root, sub_base=sub_base_default, auth_cookie=None):
+def get_list(root, sub_url=sub_url_default, auth_cookie=None):
     """
     List the nodes in a root.
 
@@ -81,7 +81,7 @@ def get_list(root, sub_base=sub_base_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to list.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -91,11 +91,11 @@ def get_list(root, sub_base=sub_base_default, auth_cookie=None):
     list
         The list of nodes in the root.
     """
-    return api_utils.get(f'{sub_base}api/list/{root}',
+    return api_utils.get(f'{sub_url}api/list/{root}',
                          auth_cookie=auth_cookie)
 
 
-def get_info(dataset, sub_base=sub_base_default, auth_cookie=None):
+def get_info(dataset, sub_url=sub_url_default, auth_cookie=None):
     """
     Get information about a dataset.
 
@@ -103,7 +103,7 @@ def get_info(dataset, sub_base=sub_base_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -113,11 +113,11 @@ def get_info(dataset, sub_base=sub_base_default, auth_cookie=None):
     dict
         The information about the dataset.
     """
-    return api_utils.get(f'{sub_base}api/info/{dataset}',
+    return api_utils.get(f'{sub_url}api/info/{dataset}',
                          auth_cookie=auth_cookie)
 
 
-def fetch(dataset, sub_base=sub_base_default, slice_=None, prefer_schunk=True,
+def fetch(dataset, sub_url=sub_url_default, slice_=None, prefer_schunk=True,
           auth_cookie=None):
     """
     Fetch a slice of a dataset.
@@ -126,7 +126,7 @@ def fetch(dataset, sub_base=sub_base_default, slice_=None, prefer_schunk=True,
     ----------
     dataset : str
         The name of the dataset.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     slice_ : str
         The slice to fetch.
@@ -144,13 +144,13 @@ def fetch(dataset, sub_base=sub_base_default, slice_=None, prefer_schunk=True,
         The slice of the dataset.
     """
     prefer_schunk = api_utils.blosc2_is_here and prefer_schunk
-    data = api_utils.fetch_data(dataset, sub_base,
+    data = api_utils.fetch_data(dataset, sub_url,
                                 {'slice_': slice_, 'prefer_schunk': prefer_schunk},
                                 auth_cookie=auth_cookie)
     return data
 
 
-def download(dataset, sub_base=sub_base_default, auth_cookie=None):
+def download(dataset, sub_url=sub_url_default, auth_cookie=None):
     """
     Download a dataset.
 
@@ -158,7 +158,7 @@ def download(dataset, sub_base=sub_base_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -172,7 +172,7 @@ def download(dataset, sub_base=sub_base_default, auth_cookie=None):
      is installed. Otherwise, it will be downloaded as-is from the internal caches (i.e.
      compressed with Blosc2, and with the `.b2` extension).
     """
-    url = api_utils.get_download_url(dataset, sub_base, auth_cookie=auth_cookie)
+    url = api_utils.get_download_url(dataset, sub_url, auth_cookie=auth_cookie)
     return api_utils.download_url(url, dataset, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 
@@ -184,20 +184,20 @@ class Root:
     If a non-empty `user_auth` mapping is given, its items are used as data to be posted
     for authenticating the user and get an authorization token for further requests.
     """
-    def __init__(self, name, sub_base=sub_base_default, user_auth=None):
+    def __init__(self, name, sub_url=sub_url_default, user_auth=None):
         self.name = name
-        self.sub_base = utils.urlbase_type(sub_base)
+        self.sub_url = utils.urlbase_type(sub_url)
         self.auth_cookie = (
-            api_utils.get_auth_cookie(sub_base, user_auth)
+            api_utils.get_auth_cookie(sub_url, user_auth)
             if user_auth else None)
 
-        ret = api_utils.post(f'{sub_base}api/subscribe/{name}',
+        ret = api_utils.post(f'{sub_url}api/subscribe/{name}',
                              auth_cookie=self.auth_cookie)
         if ret != 'Ok':
-            roots = get_roots(sub_base)
+            roots = get_roots(sub_url)
             raise ValueError(f'Could not subscribe to root {name}'
                              f' (only {roots.keys()} available)')
-        self.node_list = api_utils.get(f'{sub_base}api/list/{name}',
+        self.node_list = api_utils.get(f'{sub_url}api/list/{name}',
                                        auth_cookie=self.auth_cookie)
 
     def __repr__(self):
@@ -208,10 +208,10 @@ class Root:
         Get a file or dataset from the root.
         """
         if node.endswith((".b2nd", ".b2frame")):
-            return Dataset(node, root=self.name, sub_base=self.sub_base,
+            return Dataset(node, root=self.name, sub_url=self.sub_url,
                            auth_cookie=self.auth_cookie)
         else:
-            return File(node, root=self.name, sub_base=self.sub_base,
+            return File(node, root=self.name, sub_url=self.sub_url,
                         auth_cookie=self.auth_cookie)
 
 
@@ -225,7 +225,7 @@ class File:
         The name of the file.
     root : str
         The name of the root.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
@@ -236,7 +236,7 @@ class File:
     >>> file = root['README.md']
     >>> file.name
     'README.md'
-    >>> file.sub_base
+    >>> file.sub_url
     'http://localhost:8002/'
     >>> file.path
     PosixPath('foo/README.md')
@@ -247,13 +247,13 @@ class File:
     >>> file[0]
     b'T'
     """
-    def __init__(self, name, root, sub_base, auth_cookie=None):
+    def __init__(self, name, root, sub_url, auth_cookie=None):
         self.root = root
         self.name = name
-        self.sub_base = sub_base
+        self.sub_url = sub_url
         self.path = pathlib.Path(f'{self.root}/{self.name}')
         self.auth_cookie = auth_cookie
-        self.meta = api_utils.get(f'{sub_base}api/info/{self.path}',
+        self.meta = api_utils.get(f'{sub_url}api/info/{self.path}',
                                   auth_cookie=self.auth_cookie)
         # TODO: 'cparams' is not always present (e.g. for .b2nd files)
         # print(f"self.meta: {self.meta['cparams']}")
@@ -298,7 +298,7 @@ class File:
         'http://localhost:8002/files/foo/ds-1d.b2nd'
         """
         download_path = api_utils.get_download_url(
-            self.path, self.sub_base, auth_cookie=self.auth_cookie)
+            self.path, self.sub_url, auth_cookie=self.auth_cookie)
         return download_path
 
     def __getitem__(self, slice_):
@@ -354,7 +354,7 @@ class File:
         """
         slice_ = api_utils.slice_to_string(slice_)
         prefer_schunk = api_utils.blosc2_is_here and prefer_schunk
-        data = api_utils.fetch_data(self.path, self.sub_base,
+        data = api_utils.fetch_data(self.path, self.sub_url,
                                     {'slice_': slice_, 'prefer_schunk': prefer_schunk},
                                     auth_cookie=self.auth_cookie)
         return data
@@ -390,7 +390,7 @@ class Dataset(File):
         The name of the dataset.
     root : str
         The name of the root.
-    sub_base : str
+    sub_url : str
         The base URL of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
@@ -404,8 +404,8 @@ class Dataset(File):
     >>> ds[1:10]
     array([1, 2, 3, 4, 5, 6, 7, 8, 9])
     """
-    def __init__(self, name, root, sub_base, auth_cookie=None):
-        super().__init__(name, root, sub_base, auth_cookie)
+    def __init__(self, name, root, sub_url, auth_cookie=None):
+        super().__init__(name, root, sub_url, auth_cookie)
 
     def __repr__(self):
         # TODO: add more info about dims, types, etc.

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -144,7 +144,7 @@ def fetch(dataset, host=sub_host_default, slice_=None, prefer_schunk=True,
         The slice of the dataset.
     """
     prefer_schunk = api_utils.blosc2_is_here and prefer_schunk
-    data = api_utils.fetch_data(dataset, host,
+    data = api_utils.fetch_data(dataset, f'http://{host}/',
                                 {'slice_': slice_, 'prefer_schunk': prefer_schunk},
                                 auth_cookie=auth_cookie)
     return data
@@ -172,7 +172,7 @@ def download(dataset, host=sub_host_default, auth_cookie=None):
      is installed. Otherwise, it will be downloaded as-is from the internal caches (i.e.
      compressed with Blosc2, and with the `.b2` extension).
     """
-    url = api_utils.get_download_url(dataset, host, auth_cookie=auth_cookie)
+    url = api_utils.get_download_url(dataset, f'http://{host}/', auth_cookie=auth_cookie)
     return api_utils.download_url(url, dataset, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 
@@ -187,8 +187,9 @@ class Root:
     def __init__(self, name, host=sub_host_default, user_auth=None):
         self.name = name
         self.host = host
-        self.auth_cookie = (api_utils.get_auth_cookie(host, user_auth)
-                            if user_auth else None)
+        self.auth_cookie = (
+            api_utils.get_auth_cookie(f'http://{host}/', user_auth)
+            if user_auth else None)
 
         ret = api_utils.post(f'http://{host}/api/subscribe/{name}',
                              auth_cookie=self.auth_cookie)
@@ -297,7 +298,7 @@ class File:
         'http://localhost:8002/files/foo/ds-1d.b2nd'
         """
         download_path = api_utils.get_download_url(
-            self.path, self.host, auth_cookie=self.auth_cookie)
+            self.path, f'http://{self.host}/', auth_cookie=self.auth_cookie)
         return download_path
 
     def __getitem__(self, slice_):
@@ -353,7 +354,7 @@ class File:
         """
         slice_ = api_utils.slice_to_string(slice_)
         prefer_schunk = api_utils.blosc2_is_here and prefer_schunk
-        data = api_utils.fetch_data(self.path, self.host,
+        data = api_utils.fetch_data(self.path, f'http://{self.host}/',
                                     {'slice_': slice_, 'prefer_schunk': prefer_schunk},
                                     auth_cookie=self.auth_cookie)
         return data

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -30,15 +30,15 @@ sub_base_default = f'http://{sub_host_default}/'
 """The default base for URLs provided by the subscriber (slash-terminated)."""
 
 
-def get_roots(host=sub_host_default, auth_cookie=None):
+def get_roots(sub_base=sub_base_default, auth_cookie=None):
     """
     Get the list of available roots.
 
     Parameters
     ----------
 
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -48,10 +48,10 @@ def get_roots(host=sub_host_default, auth_cookie=None):
         The list of available roots.
 
     """
-    return api_utils.get(f'http://{host}/api/roots', auth_cookie=auth_cookie)
+    return api_utils.get(f'{sub_base}api/roots', auth_cookie=auth_cookie)
 
 
-def subscribe(root, host=sub_host_default, auth_cookie=None):
+def subscribe(root, sub_base=sub_base_default, auth_cookie=None):
     """
     Subscribe to a root.
 
@@ -59,8 +59,8 @@ def subscribe(root, host=sub_host_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to subscribe to.
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -69,11 +69,11 @@ def subscribe(root, host=sub_host_default, auth_cookie=None):
     str
         The response from the server.
     """
-    return api_utils.post(f'http://{host}/api/subscribe/{root}',
+    return api_utils.post(f'{sub_base}api/subscribe/{root}',
                           auth_cookie=auth_cookie)
 
 
-def get_list(root, host=sub_host_default, auth_cookie=None):
+def get_list(root, sub_base=sub_base_default, auth_cookie=None):
     """
     List the nodes in a root.
 
@@ -81,8 +81,8 @@ def get_list(root, host=sub_host_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to list.
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -91,11 +91,11 @@ def get_list(root, host=sub_host_default, auth_cookie=None):
     list
         The list of nodes in the root.
     """
-    return api_utils.get(f'http://{host}/api/list/{root}',
+    return api_utils.get(f'{sub_base}api/list/{root}',
                          auth_cookie=auth_cookie)
 
 
-def get_info(dataset, host=sub_host_default, auth_cookie=None):
+def get_info(dataset, sub_base=sub_base_default, auth_cookie=None):
     """
     Get information about a dataset.
 
@@ -103,8 +103,8 @@ def get_info(dataset, host=sub_host_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -113,11 +113,11 @@ def get_info(dataset, host=sub_host_default, auth_cookie=None):
     dict
         The information about the dataset.
     """
-    return api_utils.get(f'http://{host}/api/info/{dataset}',
+    return api_utils.get(f'{sub_base}api/info/{dataset}',
                          auth_cookie=auth_cookie)
 
 
-def fetch(dataset, host=sub_host_default, slice_=None, prefer_schunk=True,
+def fetch(dataset, sub_base=sub_base_default, slice_=None, prefer_schunk=True,
           auth_cookie=None):
     """
     Fetch a slice of a dataset.
@@ -126,8 +126,8 @@ def fetch(dataset, host=sub_host_default, slice_=None, prefer_schunk=True,
     ----------
     dataset : str
         The name of the dataset.
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     slice_ : str
         The slice to fetch.
     prefer_schunk : bool
@@ -144,13 +144,13 @@ def fetch(dataset, host=sub_host_default, slice_=None, prefer_schunk=True,
         The slice of the dataset.
     """
     prefer_schunk = api_utils.blosc2_is_here and prefer_schunk
-    data = api_utils.fetch_data(dataset, f'http://{host}/',
+    data = api_utils.fetch_data(dataset, sub_base,
                                 {'slice_': slice_, 'prefer_schunk': prefer_schunk},
                                 auth_cookie=auth_cookie)
     return data
 
 
-def download(dataset, host=sub_host_default, auth_cookie=None):
+def download(dataset, sub_base=sub_base_default, auth_cookie=None):
     """
     Download a dataset.
 
@@ -158,8 +158,8 @@ def download(dataset, host=sub_host_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    host : str
-        The host to query.
+    sub_base : str
+        The base URL of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -172,7 +172,7 @@ def download(dataset, host=sub_host_default, auth_cookie=None):
      is installed. Otherwise, it will be downloaded as-is from the internal caches (i.e.
      compressed with Blosc2, and with the `.b2` extension).
     """
-    url = api_utils.get_download_url(dataset, f'http://{host}/', auth_cookie=auth_cookie)
+    url = api_utils.get_download_url(dataset, sub_base, auth_cookie=auth_cookie)
     return api_utils.download_url(url, dataset, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -62,19 +62,19 @@ def parse_slice(string):
     return tuple(obj)
 
 
-def get_auth_cookie(sub_base, user_auth):
+def get_auth_cookie(sub_url, user_auth):
     if hasattr(user_auth, '_asdict'):  # named tuple (from tests)
         user_auth = user_auth._asdict()
-    resp = httpx.post(f'{sub_base}auth/jwt/login', data=user_auth)
+    resp = httpx.post(f'{sub_url}auth/jwt/login', data=user_auth)
     resp.raise_for_status()
     auth_cookie = '='.join(list(resp.cookies.items())[0])
     return auth_cookie
 
 
-def fetch_data(path, sub_base, params, auth_cookie=None):
+def fetch_data(path, sub_url, params, auth_cookie=None):
     if 'prefer_schunk' not in params:
         params['prefer_schunk'] = blosc2_is_here
-    response = _xget(f'{sub_base}api/fetch/{path}', params=params,
+    response = _xget(f'{sub_url}api/fetch/{path}', params=params,
                      auth_cookie=auth_cookie)
     data = response.content
     # Try different deserialization methods
@@ -89,8 +89,8 @@ def fetch_data(path, sub_base, params, auth_cookie=None):
     return data
 
 
-def get_download_url(path, sub_base, auth_cookie=None):
-    response = _xget(f'{sub_base}api/download-url/{path}',
+def get_download_url(path, sub_url, auth_cookie=None):
+    response = _xget(f'{sub_url}api/download-url/{path}',
                      auth_cookie=auth_cookie)
     return response.json()
 

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -62,19 +62,19 @@ def parse_slice(string):
     return tuple(obj)
 
 
-def get_auth_cookie(host, user_auth):
+def get_auth_cookie(sub_base, user_auth):
     if hasattr(user_auth, '_asdict'):  # named tuple (from tests)
         user_auth = user_auth._asdict()
-    resp = httpx.post(f'http://{host}/auth/jwt/login', data=user_auth)
+    resp = httpx.post(f'{sub_base}auth/jwt/login', data=user_auth)
     resp.raise_for_status()
     auth_cookie = '='.join(list(resp.cookies.items())[0])
     return auth_cookie
 
 
-def fetch_data(path, host, params, auth_cookie=None):
+def fetch_data(path, sub_base, params, auth_cookie=None):
     if 'prefer_schunk' not in params:
         params['prefer_schunk'] = blosc2_is_here
-    response = _xget(f'http://{host}/api/fetch/{path}', params=params,
+    response = _xget(f'{sub_base}api/fetch/{path}', params=params,
                      auth_cookie=auth_cookie)
     data = response.content
     # Try different deserialization methods
@@ -89,8 +89,8 @@ def fetch_data(path, host, params, auth_cookie=None):
     return data
 
 
-def get_download_url(path, host, auth_cookie=None):
-    response = _xget(f'http://{host}/api/download-url/{path}',
+def get_download_url(path, sub_base, auth_cookie=None):
+    response = _xget(f'{sub_base}api/download-url/{path}',
                      auth_cookie=auth_cookie)
     return response.json()
 

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -63,7 +63,8 @@ def dataset_with_slice(dataset):
 @handle_errors
 @with_auth_cookie
 def cmd_roots(args, auth_cookie):
-    data = cat2.get_roots(host=args.host, auth_cookie=auth_cookie)
+    data = cat2.get_roots(sub_base=f'http://{args.host}/',
+                          auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -78,7 +79,8 @@ def cmd_roots(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_subscribe(args, auth_cookie):
-    data = cat2.subscribe(args.root, host=args.host, auth_cookie=auth_cookie)
+    data = cat2.subscribe(args.root, sub_base=f'http://{args.host}/',
+                          auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -89,7 +91,8 @@ def cmd_subscribe(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_list(args, auth_cookie):
-    data = cat2.get_list(args.root, host=args.host, auth_cookie=auth_cookie)
+    data = cat2.get_list(args.root, sub_base=f'http://{args.host}/',
+                         auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -116,7 +119,7 @@ def cmd_url(args, auth_cookie):
 @with_auth_cookie
 def cmd_info(args, auth_cookie):
     print(f"Getting info for {args.dataset}")
-    data = cat2.get_info(args.dataset, host=args.host,
+    data = cat2.get_info(args.dataset, sub_base=f'http://{args.host}/',
                          auth_cookie=auth_cookie)
 
     # Print
@@ -132,7 +135,7 @@ def cmd_info(args, auth_cookie):
 def cmd_show(args, auth_cookie):
     dataset, params = args.dataset
     slice_ = params.get('slice_', None)
-    data = cat2.fetch(dataset, host=args.host, slice_=slice_,
+    data = cat2.fetch(dataset, sub_base=f'http://{args.host}/', slice_=slice_,
                       auth_cookie=auth_cookie)
 
     # Display
@@ -150,7 +153,7 @@ def cmd_show(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
-    path = cat2.download(args.dataset, host=args.host,
+    path = cat2.download(args.dataset, sub_base=f'http://{args.host}/',
                          auth_cookie=auth_cookie)
 
     print(f'Dataset saved to {path}')

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -156,7 +156,8 @@ def cmd_download(args, auth_cookie):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--subscriber', dest='sub_base',
+    parser.add_argument('--subscriber',
+                        dest='sub_base', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
                                          cat2.sub_base_default))
     parser.add_argument('--username', default=conf.get('client.username'))
@@ -214,8 +215,6 @@ def main():
 
     # Go
     args = utils.run_parser(parser)
-    if not args.sub_base.endswith('/'):
-        args.sub_base += '/'
     args.func(args)
 
 

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -156,8 +156,8 @@ def cmd_download(args, auth_cookie):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host',
-                        default=conf.get('subscriber.http', 'localhost:8002'))
+    parser.add_argument('--host', default=conf.get('subscriber.http',
+                                                   cat2.sub_host_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     subparsers = parser.add_subparsers(required=True)

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -156,8 +156,9 @@ def cmd_download(args, auth_cookie):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host', default=conf.get('subscriber.http',
-                                                   cat2.sub_host_default))
+    parser.add_argument('--subscriber', dest='sub_base',
+                        default=conf.get('subscriber.url',
+                                         cat2.sub_base_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     subparsers = parser.add_subparsers(required=True)
@@ -213,7 +214,8 @@ def main():
 
     # Go
     args = utils.run_parser(parser)
-    args.sub_base = f'http://{args.host}/'
+    if not args.sub_base.endswith('/'):
+        args.sub_base += '/'
     args.func(args)
 
 

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -43,7 +43,7 @@ def with_auth_cookie(func):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.sub_base, user_auth)
+            auth_cookie = api_utils.get_auth_cookie(args.sub_url, user_auth)
         return func(args, auth_cookie=auth_cookie)
     return wrapper
 
@@ -62,7 +62,7 @@ def dataset_with_slice(dataset):
 @handle_errors
 @with_auth_cookie
 def cmd_roots(args, auth_cookie):
-    data = cat2.get_roots(args.sub_base, auth_cookie=auth_cookie)
+    data = cat2.get_roots(args.sub_url, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -77,7 +77,7 @@ def cmd_roots(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_subscribe(args, auth_cookie):
-    data = cat2.subscribe(args.root, args.sub_base, auth_cookie=auth_cookie)
+    data = cat2.subscribe(args.root, args.sub_url, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -88,7 +88,7 @@ def cmd_subscribe(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_list(args, auth_cookie):
-    data = cat2.get_list(args.root, args.sub_base, auth_cookie=auth_cookie)
+    data = cat2.get_list(args.root, args.sub_url, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -102,7 +102,7 @@ def cmd_list(args, auth_cookie):
 def cmd_url(args, auth_cookie):
     # TODO: provide a url that can be used to open the dataset in blosc2
     # TODO: add a new function to the API that returns the url
-    data = api_utils.get_download_url(args.root, args.sub_base,
+    data = api_utils.get_download_url(args.root, args.sub_url,
                                       auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
@@ -115,7 +115,7 @@ def cmd_url(args, auth_cookie):
 @with_auth_cookie
 def cmd_info(args, auth_cookie):
     print(f"Getting info for {args.dataset}")
-    data = cat2.get_info(args.dataset, args.sub_base, auth_cookie=auth_cookie)
+    data = cat2.get_info(args.dataset, args.sub_url, auth_cookie=auth_cookie)
 
     # Print
     if args.json:
@@ -130,7 +130,7 @@ def cmd_info(args, auth_cookie):
 def cmd_show(args, auth_cookie):
     dataset, params = args.dataset
     slice_ = params.get('slice_', None)
-    data = cat2.fetch(dataset, args.sub_base, slice_=slice_,
+    data = cat2.fetch(dataset, args.sub_url, slice_=slice_,
                       auth_cookie=auth_cookie)
 
     # Display
@@ -148,7 +148,7 @@ def cmd_show(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
-    path = cat2.download(args.dataset, args.sub_base, auth_cookie=auth_cookie)
+    path = cat2.download(args.dataset, args.sub_url, auth_cookie=auth_cookie)
 
     print(f'Dataset saved to {path}')
 
@@ -157,9 +157,9 @@ def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
     parser.add_argument('--subscriber',
-                        dest='sub_base', type=utils.urlbase_type,
+                        dest='sub_url', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
-                                         cat2.sub_base_default))
+                                         cat2.sub_url_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     subparsers = parser.add_subparsers(required=True)

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -43,7 +43,8 @@ def with_auth_cookie(func):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.host, user_auth)
+            auth_cookie = api_utils.get_auth_cookie(f'http://{args.host}/',
+                                                    user_auth)
         return func(args, auth_cookie=auth_cookie)
     return wrapper
 
@@ -102,7 +103,7 @@ def cmd_list(args, auth_cookie):
 def cmd_url(args, auth_cookie):
     # TODO: provide a url that can be used to open the dataset in blosc2
     # TODO: add a new function to the API that returns the url
-    data = api_utils.get_download_url(args.root, args.host,
+    data = api_utils.get_download_url(args.root, f'http://{args.host}/',
                                       auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -43,8 +43,7 @@ def with_auth_cookie(func):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(f'http://{args.host}/',
-                                                    user_auth)
+            auth_cookie = api_utils.get_auth_cookie(args.sub_base, user_auth)
         return func(args, auth_cookie=auth_cookie)
     return wrapper
 
@@ -63,8 +62,7 @@ def dataset_with_slice(dataset):
 @handle_errors
 @with_auth_cookie
 def cmd_roots(args, auth_cookie):
-    data = cat2.get_roots(sub_base=f'http://{args.host}/',
-                          auth_cookie=auth_cookie)
+    data = cat2.get_roots(args.sub_base, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -79,8 +77,7 @@ def cmd_roots(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_subscribe(args, auth_cookie):
-    data = cat2.subscribe(args.root, sub_base=f'http://{args.host}/',
-                          auth_cookie=auth_cookie)
+    data = cat2.subscribe(args.root, args.sub_base, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -91,8 +88,7 @@ def cmd_subscribe(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_list(args, auth_cookie):
-    data = cat2.get_list(args.root, sub_base=f'http://{args.host}/',
-                         auth_cookie=auth_cookie)
+    data = cat2.get_list(args.root, args.sub_base, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -106,7 +102,7 @@ def cmd_list(args, auth_cookie):
 def cmd_url(args, auth_cookie):
     # TODO: provide a url that can be used to open the dataset in blosc2
     # TODO: add a new function to the API that returns the url
-    data = api_utils.get_download_url(args.root, f'http://{args.host}/',
+    data = api_utils.get_download_url(args.root, args.sub_base,
                                       auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
@@ -119,8 +115,7 @@ def cmd_url(args, auth_cookie):
 @with_auth_cookie
 def cmd_info(args, auth_cookie):
     print(f"Getting info for {args.dataset}")
-    data = cat2.get_info(args.dataset, sub_base=f'http://{args.host}/',
-                         auth_cookie=auth_cookie)
+    data = cat2.get_info(args.dataset, args.sub_base, auth_cookie=auth_cookie)
 
     # Print
     if args.json:
@@ -135,7 +130,7 @@ def cmd_info(args, auth_cookie):
 def cmd_show(args, auth_cookie):
     dataset, params = args.dataset
     slice_ = params.get('slice_', None)
-    data = cat2.fetch(dataset, sub_base=f'http://{args.host}/', slice_=slice_,
+    data = cat2.fetch(dataset, args.sub_base, slice_=slice_,
                       auth_cookie=auth_cookie)
 
     # Display
@@ -153,8 +148,7 @@ def cmd_show(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
-    path = cat2.download(args.dataset, sub_base=f'http://{args.host}/',
-                         auth_cookie=auth_cookie)
+    path = cat2.download(args.dataset, args.sub_base, auth_cookie=auth_cookie)
 
     print(f'Dataset saved to {path}')
 
@@ -219,6 +213,7 @@ def main():
 
     # Go
     args = utils.run_parser(parser)
+    args.sub_base = f'http://{args.host}/'
     args.func(args)
 
 

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -26,9 +26,9 @@ class TreeApp(App):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.sub_base, user_auth)
-        api.subscribe(args.root, args.sub_base, auth_cookie=auth_cookie)
-        self.data = api.get_list(args.root, args.sub_base,
+            auth_cookie = api_utils.get_auth_cookie(args.sub_url, user_auth)
+        api.subscribe(args.root, args.sub_url, auth_cookie=auth_cookie)
+        self.data = api.get_list(args.root, args.sub_url,
                                  auth_cookie=auth_cookie)
 
     def compose(self) -> ComposeResult:
@@ -52,9 +52,9 @@ def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
     parser.add_argument('--subscriber',
-                        dest='sub_base', type=utils.urlbase_type,
+                        dest='sub_url', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
-                                         api.sub_base_default))
+                                         api.sub_url_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     parser.add_argument('--root', default='foo')

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -28,8 +28,9 @@ class TreeApp(App):
             user_auth = dict(username=args.username, password=args.password)
             auth_cookie = api_utils.get_auth_cookie(f'http://{args.host}/',
                                                     user_auth)
-        api.subscribe(args.root, args.host, auth_cookie=auth_cookie)
-        self.data = api.get_list(args.root, args.host,
+        api.subscribe(args.root, f'http://{args.host}/',
+                      auth_cookie=auth_cookie)
+        self.data = api.get_list(args.root, f'http://{args.host}/',
                                  auth_cookie=auth_cookie)
 
     def compose(self) -> ComposeResult:

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -26,11 +26,9 @@ class TreeApp(App):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(f'http://{args.host}/',
-                                                    user_auth)
-        api.subscribe(args.root, f'http://{args.host}/',
-                      auth_cookie=auth_cookie)
-        self.data = api.get_list(args.root, f'http://{args.host}/',
+            auth_cookie = api_utils.get_auth_cookie(args.sub_base, user_auth)
+        api.subscribe(args.root, args.sub_base, auth_cookie=auth_cookie)
+        self.data = api.get_list(args.root, args.sub_base,
                                  auth_cookie=auth_cookie)
 
     def compose(self) -> ComposeResult:
@@ -61,6 +59,7 @@ def main():
 
     # Go
     args = utils.run_parser(parser)
+    args.sub_base = f'http://{args.host}/'
     app = TreeApp(args)
     app.run()
 

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -51,8 +51,8 @@ class TreeApp(App):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host',
-                        default=conf.get('subscriber.http', 'localhost:8002'))
+    parser.add_argument('--host', default=conf.get('subscriber.http',
+                                                   api.sub_host_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     parser.add_argument('--root', default='foo')

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -51,7 +51,8 @@ class TreeApp(App):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--subscriber', dest='sub_base',
+    parser.add_argument('--subscriber',
+                        dest='sub_base', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
                                          api.sub_base_default))
     parser.add_argument('--username', default=conf.get('client.username'))
@@ -60,8 +61,6 @@ def main():
 
     # Go
     args = utils.run_parser(parser)
-    if not args.sub_base.endswith('/'):
-        args.sub_base += '/'
     app = TreeApp(args)
     app.run()
 

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -26,7 +26,8 @@ class TreeApp(App):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.host, user_auth)
+            auth_cookie = api_utils.get_auth_cookie(f'http://{args.host}/',
+                                                    user_auth)
         api.subscribe(args.root, args.host, auth_cookie=auth_cookie)
         self.data = api.get_list(args.root, args.host,
                                  auth_cookie=auth_cookie)

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -51,15 +51,17 @@ class TreeApp(App):
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
-    parser.add_argument('--host', default=conf.get('subscriber.http',
-                                                   api.sub_host_default))
+    parser.add_argument('--subscriber', dest='sub_base',
+                        default=conf.get('subscriber.url',
+                                         api.sub_base_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     parser.add_argument('--root', default='foo')
 
     # Go
     args = utils.run_parser(parser)
-    args.sub_base = f'http://{args.host}/'
+    if not args.sub_base.endswith('/'):
+        args.sub_base += '/'
     app = TreeApp(args)
     app.run()
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -851,6 +851,7 @@ def main():
     _stdir = '_caterva2/sub' + (f'.{conf.id}' if conf.id else '')
     parser = utils.get_parser(broker=conf.get('broker.http', 'localhost:8000'),
                               http=conf.get('.http', 'localhost:8002'),
+                              url=conf.get('.url'),
                               loglevel=conf.get('.loglevel', 'warning'),
                               statedir=conf.get('.statedir', _stdir),
                               id=conf.id)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -54,9 +54,8 @@ cache = None
 scratch = None
 clients = {}       # topic: <PubSubClient>
 database = None    # <Database> instance
-host = None
 locks = {}
-port = None
+urlbase = None
 
 
 def make_url(request, name, query=None, **path_params):
@@ -516,7 +515,7 @@ async def download_url(path: str):
     # in the url, if it is missing.
     if abspath.suffix == '.b2':
         path = f'{path}.b2'
-    return f'http://{host}:{port}/files/{path}'
+    return f'{urlbase}files/{path}'
 
 
 @app.get('/api/download/{path:path}',
@@ -887,8 +886,9 @@ def main():
     tomography.init(cache, partial_download)
 
     # Run
-    global host, port
+    global urlbase
     host, port = args.http
+    urlbase = args.url
     uvicorn.run(app, host=host, port=port)
 
 

--- a/caterva2/tests/services.py
+++ b/caterva2/tests/services.py
@@ -217,6 +217,9 @@ class ManagedServices(Services):
     def get_endpoint(self, service):
         return self._endpoints.get(service)
 
+    def get_urlbase(self, service):
+        return 'http://%s/' % self.get_endpoint(service)
+
 
 class ExternalServices(Services):
     def __init__(self, roots=None, configuration=None):
@@ -247,6 +250,10 @@ class ExternalServices(Services):
         if service not in self._checks:
             return None
         return self._checks[service].host
+
+    def get_urlbase(self, service):
+        ep = self.get_endpoint(service)
+        return 'http://%s/' % ep if ep else None
 
 
 @pytest.fixture(scope='session')

--- a/caterva2/tests/sub_auth.py
+++ b/caterva2/tests/sub_auth.py
@@ -67,9 +67,9 @@ def sub_jwt_cookie(sub_user, services):
         return None
 
     username, password = sub_user
-    sub_host = services.get_endpoint('subscriber')
+    sub_base = services.get_urlbase('subscriber')
 
-    resp = httpx.post(f'http://{sub_host}/auth/jwt/login',
+    resp = httpx.post(f'{sub_base}auth/jwt/login',
                       data=dict(username=username, password=password))
     resp.raise_for_status()
     return '='.join(list(resp.cookies.items())[0])

--- a/caterva2/tests/sub_auth.py
+++ b/caterva2/tests/sub_auth.py
@@ -67,9 +67,9 @@ def sub_jwt_cookie(sub_user, services):
         return None
 
     username, password = sub_user
-    sub_base = services.get_urlbase('subscriber')
+    sub_url = services.get_urlbase('subscriber')
 
-    resp = httpx.post(f'{sub_base}auth/jwt/login',
+    resp = httpx.post(f'{sub_url}auth/jwt/login',
                       data=dict(username=username, password=password))
     resp.raise_for_status()
     return '='.join(list(resp.cookies.items())[0])

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -26,7 +26,7 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_base(services):
+def sub_url(services):
     return services.get_urlbase('subscriber')
 
 
@@ -39,40 +39,40 @@ def my_path(dspath, slice_):
     return dspath
 
 
-def test_roots(services, pub_host, sub_base, sub_jwt_cookie):
-    roots = cat2.get_roots(sub_base, auth_cookie=sub_jwt_cookie)
+def test_roots(services, pub_host, sub_url, sub_jwt_cookie):
+    roots = cat2.get_roots(sub_url, auth_cookie=sub_jwt_cookie)
     assert roots[TEST_CATERVA2_ROOT]['name'] == TEST_CATERVA2_ROOT
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_root(services, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_root(services, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     assert myroot.name == TEST_CATERVA2_ROOT
-    assert myroot.sub_base == sub_base
+    assert myroot.sub_url == sub_url
 
 
-def test_list(services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_list(services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     example = examples_dir
     nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 
-def test_file(services, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_file(services, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     file = myroot['README.md']
     assert file.name == 'README.md'
-    assert file.sub_base == sub_base
+    assert file.sub_url == sub_url
 
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(10, 20, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_base == sub_base
+    assert ds.sub_url == sub_url
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -84,11 +84,11 @@ def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_base
         assert ds.fetch(slice_, as_schunk) == a[slice_]
 
 
-def test_dataset_step_diff_1(services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_dataset_step_diff_1(services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_base == sub_base
+    assert ds.sub_url == sub_url
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
         _ = ds[::2]
@@ -98,11 +98,11 @@ def test_dataset_step_diff_1(services, examples_dir, sub_base, sub_user):
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
-    assert ds.sub_base == sub_base
+    assert ds.sub_url == sub_url
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -114,8 +114,8 @@ def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_base, s
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -124,9 +124,9 @@ def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_b
 
 
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
-def test_download_b2nd(name, services, examples_dir, sub_base,
+def test_download_b2nd(name, services, examples_dir, sub_url,
                        sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot[name]
     path = ds.download()
     assert path == ds.path
@@ -146,9 +146,9 @@ def test_download_b2nd(name, services, examples_dir, sub_base,
     np.testing.assert_array_equal(a[:], b[:])
 
 
-def test_download_b2frame(services, examples_dir, sub_base,
+def test_download_b2frame(services, examples_dir, sub_url,
                           sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     path = ds.download()
     assert path == ds.path
@@ -161,7 +161,7 @@ def test_download_b2frame(services, examples_dir, sub_base,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"{sub_base}files/{ds.path}"
+    assert urlpath == f"{sub_url}files/{ds.path}"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -172,8 +172,8 @@ def test_download_b2frame(services, examples_dir, sub_base,
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['README.md']
 
     # Data contents
@@ -187,9 +187,9 @@ def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_base,
         assert ds.fetch(slice_, as_schunk) == a[slice_]
 
 
-def test_download_regular_file(services, examples_dir, sub_base,
+def test_download_regular_file(services, examples_dir, sub_url,
                                sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['README.md']
     path = ds.download()
     assert path == ds.path
@@ -202,7 +202,7 @@ def test_download_regular_file(services, examples_dir, sub_base,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"{sub_base}files/{ds.path}.b2"
+    assert urlpath == f"{sub_url}files/{ds.path}.b2"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -214,14 +214,14 @@ def test_download_regular_file(services, examples_dir, sub_base,
 @pytest.mark.parametrize("name", ['ds-1d.b2nd',
                                   'ds-hello.b2frame',
                                   'README.md'])
-def test_vlmeta(name, services, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_vlmeta(name, services, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot[name]
     schunk_meta = ds.meta.get('schunk', ds.meta)
     assert ds.vlmeta is schunk_meta['vlmeta']
 
 
-def test_vlmeta_data(services, sub_base, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
+def test_vlmeta_data(services, sub_url, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
     ds = myroot['ds-sc-attr.b2nd']
     assert ds.vlmeta == dict(a=1, b="foo", c=123.456)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -46,33 +46,37 @@ def test_roots(services, pub_host, sub_host, sub_jwt_cookie):
 
 
 def test_root(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     assert myroot.name == TEST_CATERVA2_ROOT
-    assert myroot.host == sub_host
+    assert myroot.sub_base == f'http://{sub_host}/'
 
 
 def test_list(services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     example = examples_dir
     nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 
 def test_file(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     file = myroot['README.md']
     assert file.name == 'README.md'
-    assert file.host == sub_host
+    assert file.sub_base == f'http://{sub_host}/'
 
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(10, 20, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
 def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.host == sub_host
+    assert ds.sub_base == f'http://{sub_host}/'
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -85,10 +89,11 @@ def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_host
 
 
 def test_dataset_step_diff_1(services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.host == sub_host
+    assert ds.sub_base == f'http://{sub_host}/'
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
         _ = ds[::2]
@@ -99,10 +104,11 @@ def test_dataset_step_diff_1(services, examples_dir, sub_host, sub_user):
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
 def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
-    assert ds.host == sub_host
+    assert ds.sub_base == f'http://{sub_host}/'
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -115,7 +121,8 @@ def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_host, s
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
 @pytest.mark.parametrize("as_schunk", [True, False])
 def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -126,7 +133,8 @@ def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_h
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
 def test_download_b2nd(name, services, examples_dir, sub_host,
                        sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot[name]
     path = ds.download()
     assert path == ds.path
@@ -148,7 +156,8 @@ def test_download_b2nd(name, services, examples_dir, sub_host,
 
 def test_download_b2frame(services, examples_dir, sub_host,
                           sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     path = ds.download()
     assert path == ds.path
@@ -173,7 +182,8 @@ def test_download_b2frame(services, examples_dir, sub_host,
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
 def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['README.md']
 
     # Data contents
@@ -189,7 +199,8 @@ def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_host,
 
 def test_download_regular_file(services, examples_dir, sub_host,
                                sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['README.md']
     path = ds.download()
     assert path == ds.path
@@ -215,13 +226,15 @@ def test_download_regular_file(services, examples_dir, sub_host,
                                   'ds-hello.b2frame',
                                   'README.md'])
 def test_vlmeta(name, services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot[name]
     schunk_meta = ds.meta.get('schunk', ds.meta)
     assert ds.vlmeta is schunk_meta['vlmeta']
 
 
 def test_vlmeta_data(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, host=sub_host, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
+                       user_auth=sub_user)
     ds = myroot['ds-sc-attr.b2nd']
     assert ds.vlmeta == dict(a=1, b="foo", c=123.456)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -26,8 +26,8 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_host(services):
-    return services.get_endpoint('subscriber')
+def sub_base(services):
+    return services.get_urlbase('subscriber')
 
 
 def my_path(dspath, slice_):
@@ -39,44 +39,40 @@ def my_path(dspath, slice_):
     return dspath
 
 
-def test_roots(services, pub_host, sub_host, sub_jwt_cookie):
-    roots = cat2.get_roots(f'http://{sub_host}/', auth_cookie=sub_jwt_cookie)
+def test_roots(services, pub_host, sub_base, sub_jwt_cookie):
+    roots = cat2.get_roots(sub_base, auth_cookie=sub_jwt_cookie)
     assert roots[TEST_CATERVA2_ROOT]['name'] == TEST_CATERVA2_ROOT
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_root(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_root(services, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     assert myroot.name == TEST_CATERVA2_ROOT
-    assert myroot.sub_base == f'http://{sub_host}/'
+    assert myroot.sub_base == sub_base
 
 
-def test_list(services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_list(services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     example = examples_dir
     nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 
-def test_file(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_file(services, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     file = myroot['README.md']
     assert file.name == 'README.md'
-    assert file.sub_base == f'http://{sub_host}/'
+    assert file.sub_base == sub_base
 
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(10, 20, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_base == f'http://{sub_host}/'
+    assert ds.sub_base == sub_base
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -88,12 +84,11 @@ def test_index_dataset_frame(slice_, as_schunk, services, examples_dir, sub_host
         assert ds.fetch(slice_, as_schunk) == a[slice_]
 
 
-def test_dataset_step_diff_1(services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_dataset_step_diff_1(services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_base == f'http://{sub_host}/'
+    assert ds.sub_base == sub_base
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
         _ = ds[::2]
@@ -103,12 +98,11 @@ def test_dataset_step_diff_1(services, examples_dir, sub_host, sub_user):
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
-    assert ds.sub_base == f'http://{sub_host}/'
+    assert ds.sub_base == sub_base
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -120,9 +114,8 @@ def test_index_dataset_1d(slice_, as_schunk, services, examples_dir, sub_host, s
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -131,10 +124,9 @@ def test_index_dataset_nd(slice_, as_schunk, name, services, examples_dir, sub_h
 
 
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
-def test_download_b2nd(name, services, examples_dir, sub_host,
+def test_download_b2nd(name, services, examples_dir, sub_base,
                        sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot[name]
     path = ds.download()
     assert path == ds.path
@@ -154,10 +146,9 @@ def test_download_b2nd(name, services, examples_dir, sub_host,
     np.testing.assert_array_equal(a[:], b[:])
 
 
-def test_download_b2frame(services, examples_dir, sub_host,
+def test_download_b2frame(services, examples_dir, sub_base,
                           sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     path = ds.download()
     assert path == ds.path
@@ -170,7 +161,7 @@ def test_download_b2frame(services, examples_dir, sub_host,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"http://{sub_host}/files/{ds.path}"
+    assert urlpath == f"{sub_base}files/{ds.path}"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -181,9 +172,8 @@ def test_download_b2frame(services, examples_dir, sub_host,
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 @pytest.mark.parametrize("as_schunk", [True, False])
-def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['README.md']
 
     # Data contents
@@ -197,10 +187,9 @@ def test_index_regular_file(slice_, as_schunk, services, examples_dir, sub_host,
         assert ds.fetch(slice_, as_schunk) == a[slice_]
 
 
-def test_download_regular_file(services, examples_dir, sub_host,
+def test_download_regular_file(services, examples_dir, sub_base,
                                sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['README.md']
     path = ds.download()
     assert path == ds.path
@@ -213,7 +202,7 @@ def test_download_regular_file(services, examples_dir, sub_host,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"http://{sub_host}/files/{ds.path}.b2"
+    assert urlpath == f"{sub_base}files/{ds.path}.b2"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -225,16 +214,14 @@ def test_download_regular_file(services, examples_dir, sub_host,
 @pytest.mark.parametrize("name", ['ds-1d.b2nd',
                                   'ds-hello.b2frame',
                                   'README.md'])
-def test_vlmeta(name, services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_vlmeta(name, services, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot[name]
     schunk_meta = ds.meta.get('schunk', ds.meta)
     assert ds.vlmeta is schunk_meta['vlmeta']
 
 
-def test_vlmeta_data(services, sub_host, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=f'http://{sub_host}/',
-                       user_auth=sub_user)
+def test_vlmeta_data(services, sub_base, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_base=sub_base, user_auth=sub_user)
     ds = myroot['ds-sc-attr.b2nd']
     assert ds.vlmeta == dict(a=1, b="foo", c=123.456)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -40,7 +40,7 @@ def my_path(dspath, slice_):
 
 
 def test_roots(services, pub_host, sub_host, sub_jwt_cookie):
-    roots = cat2.get_roots(sub_host, auth_cookie=sub_jwt_cookie)
+    roots = cat2.get_roots(f'http://{sub_host}/', auth_cookie=sub_jwt_cookie)
     assert roots[TEST_CATERVA2_ROOT]['name'] == TEST_CATERVA2_ROOT
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 

--- a/caterva2/tests/test_cli.py
+++ b/caterva2/tests/test_cli.py
@@ -23,8 +23,8 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_host(services):
-    return services.get_endpoint(f'subscriber')
+def sub_base(services):
+    return services.get_urlbase('subscriber')
 
 
 def cli(cargs, binary=False, sub_user=None) -> str or dict:
@@ -48,9 +48,9 @@ def test_roots(services, pub_host, sub_user):
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_url(services, sub_host, sub_user):
+def test_url(services, sub_base, sub_user):
     out = cli(['url', f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'], sub_user=sub_user)
-    assert out == f'http://{sub_host}/files/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    assert out == f'{sub_base}files/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
 
 
 def test_subscribe(services, sub_user):

--- a/caterva2/tests/test_cli.py
+++ b/caterva2/tests/test_cli.py
@@ -23,7 +23,7 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_base(services):
+def sub_url(services):
     return services.get_urlbase('subscriber')
 
 
@@ -48,9 +48,9 @@ def test_roots(services, pub_host, sub_user):
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_url(services, sub_base, sub_user):
+def test_url(services, sub_url, sub_user):
     out = cli(['url', f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'], sub_user=sub_user)
-    assert out == f'{sub_base}files/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    assert out == f'{sub_url}files/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
 
 
 def test_subscribe(services, sub_user):

--- a/caterva2/tests/test_hdf5root.py
+++ b/caterva2/tests/test_hdf5root.py
@@ -21,13 +21,13 @@ hdf5root = pytest.importorskip('caterva2.services.hdf5root',
 
 
 @pytest.fixture
-def sub_base(services):
+def sub_url(services):
     return services.get_urlbase('subscriber')
 
 
 @pytest.fixture
-def api_root(sub_base, sub_user):
-    return cat2.Root(TEST_HDF5_ROOT, sub_base=sub_base, user_auth=sub_user)
+def api_root(sub_url, sub_user):
+    return cat2.Root(TEST_HDF5_ROOT, sub_url=sub_url, user_auth=sub_user)
 
 
 def test_not_unsupported(api_root):

--- a/caterva2/tests/test_hdf5root.py
+++ b/caterva2/tests/test_hdf5root.py
@@ -27,7 +27,8 @@ def sub_host(services):
 
 @pytest.fixture
 def api_root(sub_host, sub_user):
-    return cat2.Root(TEST_HDF5_ROOT, host=sub_host, user_auth=sub_user)
+    return cat2.Root(TEST_HDF5_ROOT, sub_base=f'http://{sub_host}/',
+                     user_auth=sub_user)
 
 
 def test_not_unsupported(api_root):

--- a/caterva2/tests/test_hdf5root.py
+++ b/caterva2/tests/test_hdf5root.py
@@ -21,14 +21,13 @@ hdf5root = pytest.importorskip('caterva2.services.hdf5root',
 
 
 @pytest.fixture
-def sub_host(services):
-    return services.get_endpoint('subscriber')
+def sub_base(services):
+    return services.get_urlbase('subscriber')
 
 
 @pytest.fixture
-def api_root(sub_host, sub_user):
-    return cat2.Root(TEST_HDF5_ROOT, sub_base=f'http://{sub_host}/',
-                     user_auth=sub_user)
+def api_root(sub_base, sub_user):
+    return cat2.Root(TEST_HDF5_ROOT, sub_base=sub_base, user_auth=sub_user)
 
 
 def test_not_unsupported(api_root):

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -67,15 +67,14 @@ def socket_type(string):
 
 
 def get_parser(loglevel='warning', statedir=None, id=None,
-               http=None, broker=None):
+               http=None, url=None, broker=None):
     parser = argparse.ArgumentParser()
     _add_preliminary_args(parser, id=id)  # just for help purposes
     if broker:
         parser.add_argument('--broker', default=broker)
     if http:
         parser.add_argument('--http', default=http, type=socket_type)
-        # Default value is computed after parser run.
-        parser.add_argument('--url', type=urlbase_type)
+        parser.add_argument('--url', default=url, type=urlbase_type)
     if statedir:
         parser.add_argument('--statedir', default=statedir,
                             type=pathlib.Path)

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -50,6 +50,14 @@ def walk_files(root, exclude=None):
 #
 # Command line helpers
 #
+def urlbase_type(string):
+    if not (string.startswith('http://') or string.startswith('https://')):
+        raise ValueError("invalid HTTP(S) URL base", string)
+    if not string.endswith('/'):
+        string += '/'
+    return string
+
+
 def socket_type(string):
     host, port = string.rsplit(':', maxsplit=1)
     port = int(port)
@@ -66,7 +74,8 @@ def get_parser(loglevel='warning', statedir=None, id=None,
         parser.add_argument('--broker', default=broker)
     if http:
         parser.add_argument('--http', default=http, type=socket_type)
-        parser.add_argument('--url')  # apply default on parser run
+        # Default value is computed after parser run.
+        parser.add_argument('--url', type=urlbase_type)
     if statedir:
         parser.add_argument('--statedir', default=statedir,
                             type=pathlib.Path)
@@ -85,8 +94,6 @@ def run_parser(parser):
     if hasattr(args, 'http'):
         if not args.url:
             args.url = f'http://{args.http[0]}:{args.http[1]}/'
-        if not args.url.endswith('/'):
-            args.url += '/'
 
     return args
 

--- a/caterva2/utils.py
+++ b/caterva2/utils.py
@@ -66,6 +66,7 @@ def get_parser(loglevel='warning', statedir=None, id=None,
         parser.add_argument('--broker', default=broker)
     if http:
         parser.add_argument('--http', default=http, type=socket_type)
+        parser.add_argument('--url')  # apply default on parser run
     if statedir:
         parser.add_argument('--statedir', default=statedir,
                             type=pathlib.Path)
@@ -79,6 +80,13 @@ def run_parser(parser):
     # Logging
     loglevel = args.loglevel.upper()
     logging.basicConfig(level=loglevel)
+
+    # HTTP service
+    if hasattr(args, 'http'):
+        if not args.url:
+            args.url = f'http://{args.http[0]}:{args.http[1]}/'
+        if not args.url.endswith('/'):
+            args.url += '/'
 
     return args
 

--- a/doc/reference/top_level.rst
+++ b/doc/reference/top_level.rst
@@ -44,4 +44,4 @@ Variables listed below as coming from the ``api`` module are available from the 
     api.bro_host_default
     api.pub_host_default
     api.sub_host_default
-    api.sub_base_default
+    api.sub_url_default

--- a/doc/reference/top_level.rst
+++ b/doc/reference/top_level.rst
@@ -44,3 +44,4 @@ Variables listed below as coming from the ``api`` module are available from the 
     api.bro_host_default
     api.pub_host_default
     api.sub_host_default
+    api.sub_base_default

--- a/doc/tutorials/API.md
+++ b/doc/tutorials/API.md
@@ -18,7 +18,7 @@ We just connected to the default subscriber at `localhost:8002` (you may specify
 {'foo': {'name': 'foo', 'http': 'localhost:8001', 'subscribed': None}}
 ```
 
-**Note:** If the subscriber requires user authentication, you may first get an authorization cookie with `caterva2.api_utils.get_auth_cookie('localhost:8002', {'username': '<USER>', 'password': '<PASS>'})`, then pass the returned cookie to API functions as the `auth_cookie` keyword argument.
+**Note:** If the subscriber requires user authentication, you may first get an authorization cookie with `caterva2.api_utils.get_auth_cookie('http://localhost:8002/', {'username': '<USER>', 'password': '<PASS>'})`, then pass the returned cookie to API functions as the `auth_cookie` keyword argument.
 
 Besides its name, it contains the address of the publisher providing it, and an indication that we're not subscribed to it.  Getting a list of datasets in that root with `caterva2.get_list('foo')` will fail with `404 Not Found`.  So let's try again by first subscribing to it:
 

--- a/doc/tutorials/cli.md
+++ b/doc/tutorials/cli.md
@@ -13,7 +13,7 @@ Start test Caterva2 services (see [](Launching-Caterva2-services)) first.  To as
 cat2cli roots  # -> foo (subscribed)
 ```
 
-**Note:** To choose a different subscriber, you may use the `--host` command-line option. If the subscriber requires user authentication, use the `--username` and `--password` options. To learn about the options and arguments supported by *any* Caterva2 program, just invoke it with `--help`, e.g. `cat2cli --help`.  You may also use a configuration file (see [](caterva2.toml)).
+**Note:** To choose a different subscriber, you may use the `--subscriber` command-line option. If the subscriber requires user authentication, use the `--username` and `--password` options. To learn about the options and arguments supported by *any* Caterva2 program, just invoke it with `--help`, e.g. `cat2cli --help`.  You may also use a configuration file (see [](caterva2.toml)).
 
 Though the previous command reports `foo` as subscribed (from previous sections), you may still use `subscribe` to subscribe to it (again):
 

--- a/doc/tutorials/independent-services.md
+++ b/doc/tutorials/independent-services.md
@@ -149,7 +149,7 @@ When using the programmatic API, you need to provide the subscriber address expl
 
 ```python
 roots = caterva2.get_roots(sub_base='http://sub.edu.example.org:3126/')
-foo = caterva2.Root('foo', host='sub.edu.example.org:3126')
+foo = caterva2.Root('foo', sub_base='http://sub.edu.example.org:3126/')
 ```
 
 Since parsing TOML is very easy with Python, your API client may just access the needed configuration like this:
@@ -158,5 +158,5 @@ Since parsing TOML is very easy with Python, your API client may just access the
 from tomllib import load as toml_load  # "from tomli" on Python < 3.11
 with open('caterva2.toml', 'rb') as conf_file:
     conf = toml_load(conf_file)
-foo = caterva2.Root('foo', host=conf['subscriber']['http'])
+foo = caterva2.Root('foo', sub_base=conf['subscriber']['url'])
 ```

--- a/doc/tutorials/independent-services.md
+++ b/doc/tutorials/independent-services.md
@@ -148,7 +148,7 @@ cat2cli roots
 When using the programmatic API, you need to provide the subscriber address explicitly:
 
 ```python
-roots = caterva2.get_roots(host='sub.edu.example.org:3126')
+roots = caterva2.get_roots(sub_base='http://sub.edu.example.org:3126/')
 foo = caterva2.Root('foo', host='sub.edu.example.org:3126')
 ```
 

--- a/doc/tutorials/independent-services.md
+++ b/doc/tutorials/independent-services.md
@@ -126,17 +126,17 @@ cat2sub
 
 Clients at the example workstation need to know the address of the subscriber that they will use.
 
-The command-line client `cat2cli` provides the `--host` option for that.  Running this at the workstation:
+The command-line client `cat2cli` provides the `--subscriber` option for that.  Running this at the workstation:
 
 ```sh
-cat2cli --host sub.edu.example.org:3126 roots
+cat2cli --subscriber http://sub.edu.example.org:3126/ roots
 ```
 
 Will retrieve the list of known roots from the subscriber that we set up above.  In fact, `cat2cli` also supports `caterva2.toml`, and this configuration in the current directory:
 
 ```toml
 [subscriber]
-http = "sub.edu.example.org:3126"
+url = "http://sub.edu.example.org:3126/"
 ```
 
 Should allow you to run the previous command just like this:

--- a/doc/tutorials/independent-services.md
+++ b/doc/tutorials/independent-services.md
@@ -148,8 +148,8 @@ cat2cli roots
 When using the programmatic API, you need to provide the subscriber address explicitly:
 
 ```python
-roots = caterva2.get_roots(sub_base='http://sub.edu.example.org:3126/')
-foo = caterva2.Root('foo', sub_base='http://sub.edu.example.org:3126/')
+roots = caterva2.get_roots(sub_url='http://sub.edu.example.org:3126/')
+foo = caterva2.Root('foo', sub_url='http://sub.edu.example.org:3126/')
 ```
 
 Since parsing TOML is very easy with Python, your API client may just access the needed configuration like this:
@@ -158,5 +158,5 @@ Since parsing TOML is very easy with Python, your API client may just access the
 from tomllib import load as toml_load  # "from tomli" on Python < 3.11
 with open('caterva2.toml', 'rb') as conf_file:
     conf = toml_load(conf_file)
-foo = caterva2.Root('foo', sub_base=conf['subscriber']['url'])
+foo = caterva2.Root('foo', sub_url=conf['subscriber']['url'])
 ```

--- a/doc/utilities/cat2cli.md
+++ b/doc/utilities/cat2cli.md
@@ -13,7 +13,7 @@ Running `cat2cli --help` should provide a list of supported commands that may be
 cat2cli [GENERIC_OPTION...] COMMAND [COMMAND_OPTION...] COMMAND_ARGUMENTS...
 ```
 
-A relevant generic option (besides `--help` itself) is `--host`, which overrides the subscriber address used by default.  It should have the `HOST:PORT` format (with IPv6 addresses between square brackets), for example `sub.edu.example.org:3126`.
+A relevant generic option (besides `--help` itself) is `--subscriber`, which overrides the subscriber URL base used by default.  It should be a slash-terminated HTTP(S) URL, for example `http://sub.edu.example.org:3126/`.
 
 `cat2cli` may use a TOML configuration file (`caterva2.toml` in the current directory unless overridden with the `--conf` option).  Currently, it may only get the subscriber address from there (`http` setting in `[subscriber]` section).  Command-line options override settings read from the configuration file.
 

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -19,7 +19,7 @@ import caterva2 as cat2
 
 
 # Use the demo server
-SUB_BASE = 'https://demo-api.caterva2.net/'
+SUB_URL = 'https://demo-api.caterva2.net/'
 ROOT_NAME = 'example'
 
 user_auth = None
@@ -27,16 +27,16 @@ user_auth = None
 # if the subscriber requires authentication.
 #user_auth = {'username': 'user@example.com', 'password': 'foobar'}
 
-auth_cookie = (cat2.api_utils.get_auth_cookie(SUB_BASE, user_auth)
+auth_cookie = (cat2.api_utils.get_auth_cookie(SUB_URL, user_auth)
                if user_auth else None)
 
 # Get the list of available roots
-roots = cat2.get_roots(SUB_BASE, auth_cookie=auth_cookie)
+roots = cat2.get_roots(SUB_URL, auth_cookie=auth_cookie)
 print(roots[ROOT_NAME])
 # Subscribe to a root
-response = cat2.subscribe(ROOT_NAME, SUB_BASE, auth_cookie=auth_cookie)
+response = cat2.subscribe(ROOT_NAME, SUB_URL, auth_cookie=auth_cookie)
 # Get a handle to the root
-example = cat2.Root(ROOT_NAME, sub_base=SUB_BASE, user_auth=user_auth)
+example = cat2.Root(ROOT_NAME, sub_url=SUB_URL, user_auth=user_auth)
 # List the datasets in that root
 print(example.node_list)
 # Get a specific dataset

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -32,10 +32,11 @@ auth_cookie = (cat2.api_utils.get_auth_cookie(f'http://{SUB_HOST}/',
                if user_auth else None)
 
 # Get the list of available roots
-roots = cat2.get_roots(f"{SUB_HOST}", auth_cookie=auth_cookie)
+roots = cat2.get_roots(f"http://{SUB_HOST}/", auth_cookie=auth_cookie)
 print(roots[ROOT_NAME])
 # Subscribe to a root
-response = cat2.subscribe(ROOT_NAME, f"{SUB_HOST}", auth_cookie=auth_cookie)
+response = cat2.subscribe(ROOT_NAME, f"http://{SUB_HOST}/",
+                          auth_cookie=auth_cookie)
 # Get a handle to the root
 example = cat2.Root(ROOT_NAME, host=SUB_HOST, user_auth=user_auth)
 # List the datasets in that root

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -38,7 +38,8 @@ print(roots[ROOT_NAME])
 response = cat2.subscribe(ROOT_NAME, f"http://{SUB_HOST}/",
                           auth_cookie=auth_cookie)
 # Get a handle to the root
-example = cat2.Root(ROOT_NAME, host=SUB_HOST, user_auth=user_auth)
+example = cat2.Root(ROOT_NAME, sub_base=f"http://{SUB_HOST}/",
+                    user_auth=user_auth)
 # List the datasets in that root
 print(example.node_list)
 # Get a specific dataset

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -19,7 +19,7 @@ import caterva2 as cat2
 
 
 # Use the demo server
-SUB_HOST = 'demo-api.caterva2.net:8202'
+SUB_BASE = 'http://demo-api.caterva2.net:8202/'
 ROOT_NAME = 'example'
 
 user_auth = None
@@ -27,19 +27,16 @@ user_auth = None
 # if the subscriber requires authentication.
 #user_auth = {'username': 'user@example.com', 'password': 'foobar'}
 
-auth_cookie = (cat2.api_utils.get_auth_cookie(f'http://{SUB_HOST}/',
-                                              user_auth)
+auth_cookie = (cat2.api_utils.get_auth_cookie(SUB_BASE, user_auth)
                if user_auth else None)
 
 # Get the list of available roots
-roots = cat2.get_roots(f"http://{SUB_HOST}/", auth_cookie=auth_cookie)
+roots = cat2.get_roots(SUB_BASE, auth_cookie=auth_cookie)
 print(roots[ROOT_NAME])
 # Subscribe to a root
-response = cat2.subscribe(ROOT_NAME, f"http://{SUB_HOST}/",
-                          auth_cookie=auth_cookie)
+response = cat2.subscribe(ROOT_NAME, SUB_BASE, auth_cookie=auth_cookie)
 # Get a handle to the root
-example = cat2.Root(ROOT_NAME, sub_base=f"http://{SUB_HOST}/",
-                    user_auth=user_auth)
+example = cat2.Root(ROOT_NAME, sub_base=SUB_BASE, user_auth=user_auth)
 # List the datasets in that root
 print(example.node_list)
 # Get a specific dataset

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -27,7 +27,8 @@ user_auth = None
 # if the subscriber requires authentication.
 #user_auth = {'username': 'user@example.com', 'password': 'foobar'}
 
-auth_cookie = (cat2.api_utils.get_auth_cookie(SUB_HOST, user_auth)
+auth_cookie = (cat2.api_utils.get_auth_cookie(f'http://{SUB_HOST}/',
+                                              user_auth)
                if user_auth else None)
 
 # Get the list of available roots

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -19,7 +19,7 @@ import caterva2 as cat2
 
 
 # Use the demo server
-SUB_BASE = 'http://demo-api.caterva2.net:8202/'
+SUB_BASE = 'https://demo-api.caterva2.net/'
 ROOT_NAME = 'example'
 
 user_auth = None


### PR DESCRIPTION
This allows to provide the subscriber with the URL to be used as a base for its public service. For instance, a subscriber behind a reverse proxy may listen on `localhost:8002` (`subscriber.http`) but be accessible in `https://cat2.example.com/` (`subscriber.url`). The latter is used in API and web client responses that need to include complete, public subscriber URLs, thus fixing the issue that a subscriber behind a reverse proxy could either provide a working web client or a working API, but not both.

The `--host` option in clients (`HOST:PORT`, default to `subscriber.http`) has been replaced by the `--subscriber` option (URL base, default to `subscriber.url`), with docs and tests updated.