### PR TITLE
Urlbase renames for consistency

### DIFF
--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -13,6 +13,6 @@ __version__ = "0.2.1.dev0"
 """The version in use of the Caterva2 package."""
 
 from .api import (bro_host_default, pub_host_default, sub_host_default,
-                  sub_url_default)
+                  sub_urlbase_default)
 from .api import get_roots, subscribe, get_list, get_info, fetch, download
 from .api import Root, File, Dataset

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -30,30 +30,30 @@ sub_urlbase_default = f'http://{sub_host_default}/'
 """The default base for URLs provided by the subscriber (slash-terminated)."""
 
 
-def _format_paths(sub_url, path=None):
-    if sub_url is not None:
-        if isinstance(sub_url, pathlib.Path):
-            sub_url = sub_url.as_posix()
-        if not sub_url.endswith("/"):
-            sub_url += "/"
-            sub_url = pathlib.Path(sub_url)
+def _format_paths(urlbase, path=None):
+    if urlbase is not None:
+        if isinstance(urlbase, pathlib.Path):
+            urlbase = urlbase.as_posix()
+        if not urlbase.endswith("/"):
+            urlbase += "/"
+            urlbase = pathlib.Path(urlbase)
     if path is not None:
         p = path.as_posix() if isinstance(path, pathlib.Path) else path
         if p.startswith("/"):
             raise ValueError("The path should not start with a slash")
         if p.endswith("/"):
             raise ValueError("The path should not end with a slash")
-    return sub_url, path
+    return urlbase, path
 
 
-def get_roots(sub_url=sub_urlbase_default, auth_cookie=None):
+def get_roots(urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Get the list of available roots.
 
     Parameters
     ----------
 
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -64,11 +64,11 @@ def get_roots(sub_url=sub_urlbase_default, auth_cookie=None):
         The list of available roots.
 
     """
-    sub_url, _ = _format_paths(sub_url)
-    return api_utils.get(f'{sub_url}api/roots', auth_cookie=auth_cookie)
+    urlbase, _ = _format_paths(urlbase)
+    return api_utils.get(f'{urlbase}api/roots', auth_cookie=auth_cookie)
 
 
-def subscribe(root, sub_url=sub_urlbase_default, auth_cookie=None):
+def subscribe(root, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Subscribe to a root.
 
@@ -76,7 +76,7 @@ def subscribe(root, sub_url=sub_urlbase_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to subscribe to.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -86,12 +86,12 @@ def subscribe(root, sub_url=sub_urlbase_default, auth_cookie=None):
     str
         The response from the server.
     """
-    sub_url, root = _format_paths(sub_url, root)
-    return api_utils.post(f'{sub_url}api/subscribe/{root}',
+    urlbase, root = _format_paths(urlbase, root)
+    return api_utils.post(f'{urlbase}api/subscribe/{root}',
                           auth_cookie=auth_cookie)
 
 
-def get_list(root, sub_url=sub_urlbase_default, auth_cookie=None):
+def get_list(root, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     List the nodes in a root.
 
@@ -99,7 +99,7 @@ def get_list(root, sub_url=sub_urlbase_default, auth_cookie=None):
     ----------
     root : str
         The name of the root to list.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -109,12 +109,12 @@ def get_list(root, sub_url=sub_urlbase_default, auth_cookie=None):
     list
         The list of nodes in the root.
     """
-    sub_url, root = _format_paths(sub_url, root)
-    return api_utils.get(f'{sub_url}api/list/{root}',
+    urlbase, root = _format_paths(urlbase, root)
+    return api_utils.get(f'{urlbase}api/list/{root}',
                          auth_cookie=auth_cookie)
 
 
-def get_info(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
+def get_info(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Get information about a dataset.
 
@@ -122,7 +122,7 @@ def get_info(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -132,12 +132,12 @@ def get_info(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
     dict
         The information about the dataset.
     """
-    sub_url, dataset = _format_paths(sub_url, dataset)
-    return api_utils.get(f'{sub_url}api/info/{dataset}',
+    urlbase, dataset = _format_paths(urlbase, dataset)
+    return api_utils.get(f'{urlbase}api/info/{dataset}',
                          auth_cookie=auth_cookie)
 
 
-def fetch(dataset, sub_url=sub_urlbase_default, slice_=None,
+def fetch(dataset, urlbase=sub_urlbase_default, slice_=None,
           auth_cookie=None):
     """
     Fetch a slice of a dataset.
@@ -146,7 +146,7 @@ def fetch(dataset, sub_url=sub_urlbase_default, slice_=None,
     ----------
     dataset : str
         The name of the dataset.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     slice_ : str
         The slice to fetch.
@@ -158,14 +158,14 @@ def fetch(dataset, sub_url=sub_urlbase_default, slice_=None,
     numpy.ndarray
         The slice of the dataset.
     """
-    sub_url, dataset = _format_paths(sub_url, dataset)
-    data = api_utils.fetch_data(dataset, sub_url,
+    urlbase, dataset = _format_paths(urlbase, dataset)
+    data = api_utils.fetch_data(dataset, urlbase,
                                 {'slice_': slice_},
                                 auth_cookie=auth_cookie)
     return data
 
 
-def download(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
+def download(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Download a dataset.
 
@@ -173,7 +173,7 @@ def download(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
     ----------
     dataset : str
         The name of the dataset.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
@@ -187,8 +187,8 @@ def download(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
      is installed. Otherwise, it will be downloaded as-is from the internal caches (i.e.
      compressed with Blosc2, and with the `.b2` extension).
     """
-    sub_url, dataset = _format_paths(sub_url, dataset)
-    url = api_utils.get_download_url(dataset, sub_url)
+    urlbase, dataset = _format_paths(urlbase, dataset)
+    url = api_utils.get_download_url(dataset, urlbase)
     return api_utils.download_url(url, dataset, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 
@@ -200,21 +200,21 @@ class Root:
     If a non-empty `user_auth` mapping is given, its items are used as data to be posted
     for authenticating the user and get an authorization token for further requests.
     """
-    def __init__(self, name, sub_url=sub_urlbase_default, user_auth=None):
-        sub_url, name = _format_paths(sub_url, name)
+    def __init__(self, name, urlbase=sub_urlbase_default, user_auth=None):
+        urlbase, name = _format_paths(urlbase, name)
         self.name = name
-        self.sub_url = utils.urlbase_type(sub_url)
+        self.urlbase = utils.urlbase_type(urlbase)
         self.auth_cookie = (
-            api_utils.get_auth_cookie(sub_url, user_auth)
+            api_utils.get_auth_cookie(urlbase, user_auth)
             if user_auth else None)
 
-        ret = api_utils.post(f'{sub_url}api/subscribe/{name}',
+        ret = api_utils.post(f'{urlbase}api/subscribe/{name}',
                              auth_cookie=self.auth_cookie)
         if ret != 'Ok':
-            roots = get_roots(sub_url)
+            roots = get_roots(urlbase)
             raise ValueError(f'Could not subscribe to root {name}'
                              f' (only {roots.keys()} available)')
-        self.node_list = api_utils.get(f'{sub_url}api/list/{name}',
+        self.node_list = api_utils.get(f'{urlbase}api/list/{name}',
                                        auth_cookie=self.auth_cookie)
 
     def __repr__(self):
@@ -225,10 +225,10 @@ class Root:
         Get a file or dataset from the root.
         """
         if node.endswith((".b2nd", ".b2frame")):
-            return Dataset(node, root=self.name, sub_url=self.sub_url,
+            return Dataset(node, root=self.name, urlbase=self.urlbase,
                            auth_cookie=self.auth_cookie)
         else:
-            return File(node, root=self.name, sub_url=self.sub_url,
+            return File(node, root=self.name, urlbase=self.urlbase,
                         auth_cookie=self.auth_cookie)
 
 
@@ -242,7 +242,7 @@ class File:
         The name of the file.
     root : str
         The name of the root.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
@@ -253,7 +253,7 @@ class File:
     >>> file = root['README.md']
     >>> file.name
     'README.md'
-    >>> file.sub_url
+    >>> file.urlbase
     'http://localhost:8002/'
     >>> file.path
     PosixPath('foo/README.md')
@@ -264,15 +264,15 @@ class File:
     >>> file[0]
     b'T'
     """
-    def __init__(self, name, root, sub_url, auth_cookie=None):
-        sub_url, name = _format_paths(sub_url, name)
+    def __init__(self, name, root, urlbase, auth_cookie=None):
+        urlbase, name = _format_paths(urlbase, name)
         _, root = _format_paths(None, root)
         self.root = root
         self.name = name
-        self.sub_url = sub_url
+        self.urlbase = urlbase
         self.path = pathlib.Path(f'{self.root}/{self.name}')
         self.auth_cookie = auth_cookie
-        self.meta = api_utils.get(f'{sub_url}api/info/{self.path}',
+        self.meta = api_utils.get(f'{urlbase}api/info/{self.path}',
                                   auth_cookie=self.auth_cookie)
         # TODO: 'cparams' is not always present (e.g. for .b2nd files)
         # print(f"self.meta: {self.meta['cparams']}")
@@ -316,7 +316,7 @@ class File:
         >>> file.get_download_url()
         'http://localhost:8002/api/fetch/foo/ds-1d.b2nd'
         """
-        return api_utils.get_download_url(self.path, self.sub_url)
+        return api_utils.get_download_url(self.path, self.urlbase)
 
     def __getitem__(self, slice_):
         """
@@ -365,7 +365,7 @@ class File:
             The slice of the dataset.
         """
         slice_ = api_utils.slice_to_string(slice_)
-        data = api_utils.fetch_data(self.path, self.sub_url,
+        data = api_utils.fetch_data(self.path, self.urlbase,
                                     {'slice_': slice_},
                                     auth_cookie=self.auth_cookie)
         return data
@@ -401,7 +401,7 @@ class Dataset(File):
         The name of the dataset.
     root : str
         The name of the root.
-    sub_url : str
+    urlbase : str
         The base URL (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
@@ -415,8 +415,8 @@ class Dataset(File):
     >>> ds[1:10]
     array([1, 2, 3, 4, 5, 6, 7, 8, 9])
     """
-    def __init__(self, name, root, sub_url, auth_cookie=None):
-        super().__init__(name, root, sub_url, auth_cookie)
+    def __init__(self, name, root, urlbase, auth_cookie=None):
+        super().__init__(name, root, urlbase, auth_cookie)
 
     def __repr__(self):
         # TODO: add more info about dims, types, etc.

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -27,7 +27,7 @@ sub_host_default = 'localhost:8002'
 """The default HTTP endpoint for the subscriber (URL host & port)."""
 
 sub_urlbase_default = f'http://{sub_host_default}/'
-"""The default base for URLs provided by the subscriber (slash-terminated)."""
+"""The default base of URLs provided by the subscriber (slash-terminated)."""
 
 
 def _format_paths(urlbase, path=None):
@@ -54,7 +54,7 @@ def get_roots(urlbase=sub_urlbase_default, auth_cookie=None):
     ----------
 
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -77,7 +77,7 @@ def subscribe(root, urlbase=sub_urlbase_default, auth_cookie=None):
     root : str
         The name of the root to subscribe to.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -100,7 +100,7 @@ def get_list(root, urlbase=sub_urlbase_default, auth_cookie=None):
     root : str
         The name of the root to list.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -123,7 +123,7 @@ def get_info(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
     dataset : str
         The name of the dataset.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -147,7 +147,7 @@ def fetch(dataset, urlbase=sub_urlbase_default, slice_=None,
     dataset : str
         The name of the dataset.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     slice_ : str
         The slice to fetch.
     auth_cookie : str
@@ -174,7 +174,7 @@ def download(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
     dataset : str
         The name of the dataset.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
         An optional HTTP cookie for authorizing access.
 
@@ -243,7 +243,7 @@ class File:
     root : str
         The name of the root.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
 
@@ -402,7 +402,7 @@ class Dataset(File):
     root : str
         The name of the root.
     urlbase : str
-        The base URL (slash-terminated) of the subscriber to query.
+        The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie: str
         An optional cookie to authorize requests via HTTP.
 

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -121,7 +121,7 @@ def get_info(path, urlbase=sub_urlbase_default, auth_cookie=None):
     Parameters
     ----------
     path : str
-        The name of the dataset.
+        The path of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str
@@ -145,7 +145,7 @@ def fetch(path, urlbase=sub_urlbase_default, slice_=None,
     Parameters
     ----------
     path : str
-        The name of the dataset.
+        The path of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
     slice_ : str
@@ -172,7 +172,7 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
     Parameters
     ----------
     path : str
-        The name of the dataset.
+        The path of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
     auth_cookie : str

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -114,13 +114,13 @@ def get_list(root, urlbase=sub_urlbase_default, auth_cookie=None):
                          auth_cookie=auth_cookie)
 
 
-def get_info(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
+def get_info(path, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Get information about a dataset.
 
     Parameters
     ----------
-    dataset : str
+    path : str
         The name of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
@@ -132,19 +132,19 @@ def get_info(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
     dict
         The information about the dataset.
     """
-    urlbase, dataset = _format_paths(urlbase, dataset)
-    return api_utils.get(f'{urlbase}api/info/{dataset}',
+    urlbase, path = _format_paths(urlbase, path)
+    return api_utils.get(f'{urlbase}api/info/{path}',
                          auth_cookie=auth_cookie)
 
 
-def fetch(dataset, urlbase=sub_urlbase_default, slice_=None,
+def fetch(path, urlbase=sub_urlbase_default, slice_=None,
           auth_cookie=None):
     """
     Fetch a slice of a dataset.
 
     Parameters
     ----------
-    dataset : str
+    path : str
         The name of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
@@ -158,20 +158,20 @@ def fetch(dataset, urlbase=sub_urlbase_default, slice_=None,
     numpy.ndarray
         The slice of the dataset.
     """
-    urlbase, dataset = _format_paths(urlbase, dataset)
-    data = api_utils.fetch_data(dataset, urlbase,
+    urlbase, path = _format_paths(urlbase, path)
+    data = api_utils.fetch_data(path, urlbase,
                                 {'slice_': slice_},
                                 auth_cookie=auth_cookie)
     return data
 
 
-def download(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
+def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Download a dataset.
 
     Parameters
     ----------
-    dataset : str
+    path : str
         The name of the dataset.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
@@ -187,9 +187,9 @@ def download(dataset, urlbase=sub_urlbase_default, auth_cookie=None):
      is installed. Otherwise, it will be downloaded as-is from the internal caches (i.e.
      compressed with Blosc2, and with the `.b2` extension).
     """
-    urlbase, dataset = _format_paths(urlbase, dataset)
-    url = api_utils.get_download_url(dataset, urlbase)
-    return api_utils.download_url(url, dataset, try_unpack=api_utils.blosc2_is_here,
+    urlbase, path = _format_paths(urlbase, path)
+    url = api_utils.get_download_url(path, urlbase)
+    return api_utils.download_url(url, path, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 
 

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -26,7 +26,7 @@ pub_host_default = 'localhost:8001'
 sub_host_default = 'localhost:8002'
 """The default HTTP endpoint for the subscriber (URL host & port)."""
 
-sub_url_default = f'http://{sub_host_default}/'
+sub_urlbase_default = f'http://{sub_host_default}/'
 """The default base for URLs provided by the subscriber (slash-terminated)."""
 
 
@@ -46,7 +46,7 @@ def _format_paths(sub_url, path=None):
     return sub_url, path
 
 
-def get_roots(sub_url=sub_url_default, auth_cookie=None):
+def get_roots(sub_url=sub_urlbase_default, auth_cookie=None):
     """
     Get the list of available roots.
 
@@ -68,7 +68,7 @@ def get_roots(sub_url=sub_url_default, auth_cookie=None):
     return api_utils.get(f'{sub_url}api/roots', auth_cookie=auth_cookie)
 
 
-def subscribe(root, sub_url=sub_url_default, auth_cookie=None):
+def subscribe(root, sub_url=sub_urlbase_default, auth_cookie=None):
     """
     Subscribe to a root.
 
@@ -91,7 +91,7 @@ def subscribe(root, sub_url=sub_url_default, auth_cookie=None):
                           auth_cookie=auth_cookie)
 
 
-def get_list(root, sub_url=sub_url_default, auth_cookie=None):
+def get_list(root, sub_url=sub_urlbase_default, auth_cookie=None):
     """
     List the nodes in a root.
 
@@ -114,7 +114,7 @@ def get_list(root, sub_url=sub_url_default, auth_cookie=None):
                          auth_cookie=auth_cookie)
 
 
-def get_info(dataset, sub_url=sub_url_default, auth_cookie=None):
+def get_info(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
     """
     Get information about a dataset.
 
@@ -137,7 +137,8 @@ def get_info(dataset, sub_url=sub_url_default, auth_cookie=None):
                          auth_cookie=auth_cookie)
 
 
-def fetch(dataset, sub_url=sub_url_default, slice_=None, auth_cookie=None):
+def fetch(dataset, sub_url=sub_urlbase_default, slice_=None,
+          auth_cookie=None):
     """
     Fetch a slice of a dataset.
 
@@ -164,7 +165,7 @@ def fetch(dataset, sub_url=sub_url_default, slice_=None, auth_cookie=None):
     return data
 
 
-def download(dataset, sub_url=sub_url_default, auth_cookie=None):
+def download(dataset, sub_url=sub_urlbase_default, auth_cookie=None):
     """
     Download a dataset.
 
@@ -199,7 +200,7 @@ class Root:
     If a non-empty `user_auth` mapping is given, its items are used as data to be posted
     for authenticating the user and get an authorization token for further requests.
     """
-    def __init__(self, name, sub_url=sub_url_default, user_auth=None):
+    def __init__(self, name, sub_url=sub_urlbase_default, user_auth=None):
         sub_url, name = _format_paths(sub_url, name)
         self.name = name
         self.sub_url = utils.urlbase_type(sub_url)

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -61,17 +61,17 @@ def parse_slice(string):
     return tuple(obj)
 
 
-def get_auth_cookie(sub_url, user_auth):
+def get_auth_cookie(urlbase, user_auth):
     if hasattr(user_auth, '_asdict'):  # named tuple (from tests)
         user_auth = user_auth._asdict()
-    resp = httpx.post(f'{sub_url}auth/jwt/login', data=user_auth)
+    resp = httpx.post(f'{urlbase}auth/jwt/login', data=user_auth)
     resp.raise_for_status()
     auth_cookie = '='.join(list(resp.cookies.items())[0])
     return auth_cookie
 
 
-def fetch_data(path, sub_url, params, auth_cookie=None):
-    response = _xget(f'{sub_url}api/fetch/{path}', params=params,
+def fetch_data(path, urlbase, params, auth_cookie=None):
+    response = _xget(f'{urlbase}api/fetch/{path}', params=params,
                      auth_cookie=auth_cookie)
     data = response.content
     # Try different deserialization methods
@@ -84,8 +84,8 @@ def fetch_data(path, sub_url, params, auth_cookie=None):
     return data
 
 
-def get_download_url(path, sub_url):
-    return f'{sub_url}api/fetch/{path}'
+def get_download_url(path, urlbase):
+    return f'{urlbase}api/fetch/{path}'
 
 
 def b2_unpack(filepath):

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -21,13 +21,6 @@ except ImportError:
     blosc2_is_here = False
 
 
-def split_dsname(path):
-    ds = str(path)
-    root_sep = ds.find('/')
-    root, dsname = ds[:root_sep], ds[root_sep + 1:]
-    return dsname, root
-
-
 def slice_to_string(slice_):
     if slice_ is None or slice_ == () or slice_ == slice(None):
         return ''

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -21,8 +21,8 @@ except ImportError:
     blosc2_is_here = False
 
 
-def split_dsname(dataset):
-    ds = str(dataset)
+def split_dsname(path):
+    ds = str(path)
     root_sep = ds.find('/')
     root, dsname = ds[:root_sep], ds[root_sep + 1:]
     return dsname, root

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -43,7 +43,7 @@ def with_auth_cookie(func):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.sub_url, user_auth)
+            auth_cookie = api_utils.get_auth_cookie(args.urlbase, user_auth)
         return func(args, auth_cookie=auth_cookie)
     return wrapper
 
@@ -62,7 +62,7 @@ def dataset_with_slice(dataset):
 @handle_errors
 @with_auth_cookie
 def cmd_roots(args, auth_cookie):
-    data = cat2.get_roots(args.sub_url, auth_cookie=auth_cookie)
+    data = cat2.get_roots(args.urlbase, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -77,7 +77,7 @@ def cmd_roots(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_subscribe(args, auth_cookie):
-    data = cat2.subscribe(args.root, args.sub_url, auth_cookie=auth_cookie)
+    data = cat2.subscribe(args.root, args.urlbase, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -88,7 +88,7 @@ def cmd_subscribe(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_list(args, auth_cookie):
-    data = cat2.get_list(args.root, args.sub_url, auth_cookie=auth_cookie)
+    data = cat2.get_list(args.root, args.urlbase, auth_cookie=auth_cookie)
     if args.json:
         print(json.dumps(data))
         return
@@ -100,7 +100,7 @@ def cmd_list(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_url(args, auth_cookie):
-    data = api_utils.get_download_url(args.dataset, args.sub_url)
+    data = api_utils.get_download_url(args.dataset, args.urlbase)
     if args.json:
         print(json.dumps(data))
         return
@@ -112,7 +112,7 @@ def cmd_url(args, auth_cookie):
 @with_auth_cookie
 def cmd_info(args, auth_cookie):
     print(f"Getting info for {args.dataset}")
-    data = cat2.get_info(args.dataset, args.sub_url, auth_cookie=auth_cookie)
+    data = cat2.get_info(args.dataset, args.urlbase, auth_cookie=auth_cookie)
 
     # Print
     if args.json:
@@ -127,7 +127,7 @@ def cmd_info(args, auth_cookie):
 def cmd_show(args, auth_cookie):
     dataset, params = args.dataset
     slice_ = params.get('slice_', None)
-    data = cat2.fetch(dataset, args.sub_url, slice_=slice_,
+    data = cat2.fetch(dataset, args.urlbase, slice_=slice_,
                       auth_cookie=auth_cookie)
 
     # Display
@@ -145,7 +145,7 @@ def cmd_show(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
-    path = cat2.download(args.dataset, args.sub_url, auth_cookie=auth_cookie)
+    path = cat2.download(args.dataset, args.urlbase, auth_cookie=auth_cookie)
 
     print(f'Dataset saved to {path}')
 
@@ -154,7 +154,7 @@ def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
     parser.add_argument('--subscriber',
-                        dest='sub_url', type=utils.urlbase_type,
+                        dest='urlbase', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
                                          cat2.sub_urlbase_default))
     parser.add_argument('--username', default=conf.get('client.username'))

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -48,15 +48,15 @@ def with_auth_cookie(func):
     return wrapper
 
 
-def dataset_with_slice(dataset):
-    match = re.match('(.*)\\[(.*)]', dataset)
+def dataset_with_slice(path):
+    match = re.match('(.*)\\[(.*)]', path)
     if match is None:
         params = {}
     else:
-        dataset, slice_ = match.groups()
+        path, slice_ = match.groups()
         params = {'slice_': slice_}
 
-    return pathlib.Path(dataset), params
+    return pathlib.Path(path), params
 
 
 @handle_errors
@@ -125,9 +125,9 @@ def cmd_info(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_show(args, auth_cookie):
-    dataset, params = args.dataset
+    path, params = args.dataset
     slice_ = params.get('slice_', None)
-    data = cat2.fetch(dataset, args.urlbase, slice_=slice_,
+    data = cat2.fetch(path, args.urlbase, slice_=slice_,
                       auth_cookie=auth_cookie)
 
     # Display

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -156,7 +156,7 @@ def main():
     parser.add_argument('--subscriber',
                         dest='sub_url', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
-                                         cat2.sub_url_default))
+                                         cat2.sub_urlbase_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     subparsers = parser.add_subparsers(required=True)

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -54,7 +54,7 @@ def main():
     parser.add_argument('--subscriber',
                         dest='sub_url', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
-                                         api.sub_url_default))
+                                         api.sub_urlbase_default))
     parser.add_argument('--username', default=conf.get('client.username'))
     parser.add_argument('--password', default=conf.get('client.password'))
     parser.add_argument('--root', default='foo')

--- a/caterva2/clients/tbrowser.py
+++ b/caterva2/clients/tbrowser.py
@@ -26,9 +26,9 @@ class TreeApp(App):
         auth_cookie = None
         if args.username and args.password:
             user_auth = dict(username=args.username, password=args.password)
-            auth_cookie = api_utils.get_auth_cookie(args.sub_url, user_auth)
-        api.subscribe(args.root, args.sub_url, auth_cookie=auth_cookie)
-        self.data = api.get_list(args.root, args.sub_url,
+            auth_cookie = api_utils.get_auth_cookie(args.urlbase, user_auth)
+        api.subscribe(args.root, args.urlbase, auth_cookie=auth_cookie)
+        self.data = api.get_list(args.root, args.urlbase,
                                  auth_cookie=auth_cookie)
 
     def compose(self) -> ComposeResult:
@@ -52,7 +52,7 @@ def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
     parser.add_argument('--subscriber',
-                        dest='sub_url', type=utils.urlbase_type,
+                        dest='urlbase', type=utils.urlbase_type,
                         default=conf.get('subscriber.url',
                                          api.sub_urlbase_default))
     parser.add_argument('--username', default=conf.get('client.username'))

--- a/caterva2/tests/sub_auth.py
+++ b/caterva2/tests/sub_auth.py
@@ -67,9 +67,9 @@ def sub_jwt_cookie(sub_user, services):
         return None
 
     username, password = sub_user
-    sub_url = services.get_urlbase('subscriber')
+    urlbase = services.get_urlbase('subscriber')
 
-    resp = httpx.post(f'{sub_url}auth/jwt/login',
+    resp = httpx.post(f'{urlbase}auth/jwt/login',
                       data=dict(username=username, password=password))
     resp.raise_for_status()
     return '='.join(list(resp.cookies.items())[0])

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -26,7 +26,7 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_url(services):
+def sub_urlbase(services):
     return services.get_urlbase('subscriber')
 
 
@@ -39,39 +39,44 @@ def my_path(dspath, slice_):
     return dspath
 
 
-def test_roots(services, pub_host, sub_url, sub_jwt_cookie):
-    roots = cat2.get_roots(sub_url, auth_cookie=sub_jwt_cookie)
+def test_roots(services, pub_host, sub_urlbase, sub_jwt_cookie):
+    roots = cat2.get_roots(sub_urlbase, auth_cookie=sub_jwt_cookie)
     assert roots[TEST_CATERVA2_ROOT]['name'] == TEST_CATERVA2_ROOT
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_root(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_root(services, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     assert myroot.name == TEST_CATERVA2_ROOT
-    assert myroot.urlbase == sub_url
+    assert myroot.urlbase == sub_urlbase
 
 
-def test_list(services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_list(services, examples_dir, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     example = examples_dir
     nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 
-def test_file(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_file(services, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     file = myroot['README.md']
     assert file.name == 'README.md'
-    assert file.urlbase == sub_url
+    assert file.urlbase == sub_urlbase
 
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(10, 20, 1)])
-def test_index_dataset_frame(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_index_dataset_frame(slice_, services, examples_dir, sub_urlbase,
+                             sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.urlbase == sub_url
+    assert ds.urlbase == sub_urlbase
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -83,11 +88,12 @@ def test_index_dataset_frame(slice_, services, examples_dir, sub_url, sub_user):
         assert ds.fetch(slice_) == a[slice_]
 
 
-def test_dataset_step_diff_1(services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_dataset_step_diff_1(services, examples_dir, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.urlbase == sub_url
+    assert ds.urlbase == sub_urlbase
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
         _ = ds[::2]
@@ -96,11 +102,13 @@ def test_dataset_step_diff_1(services, examples_dir, sub_url, sub_user):
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
-def test_index_dataset_1d(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_index_dataset_1d(slice_, services, examples_dir, sub_urlbase,
+                          sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
-    assert ds.urlbase == sub_url
+    assert ds.urlbase == sub_urlbase
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -111,8 +119,10 @@ def test_index_dataset_1d(slice_, services, examples_dir, sub_url, sub_user):
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1), (slice(None, 10), slice(None, 20))])
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
-def test_index_dataset_nd(slice_, name, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_index_dataset_nd(slice_, name, services, examples_dir, sub_urlbase,
+                          sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -121,9 +131,10 @@ def test_index_dataset_nd(slice_, name, services, examples_dir, sub_url, sub_use
 
 
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
-def test_download_b2nd(name, services, examples_dir, sub_url,
+def test_download_b2nd(name, services, examples_dir, sub_urlbase,
                        sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot[name]
     path = ds.download()
     assert path == ds.path
@@ -143,9 +154,9 @@ def test_download_b2nd(name, services, examples_dir, sub_url,
     np.testing.assert_array_equal(a[:], b[:])
 
 
-def test_download_b2frame(services, examples_dir, sub_url,
+def test_download_b2frame(services, examples_dir, sub_urlbase,
                           sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_urlbase, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     path = ds.download()
     assert path == ds.path
@@ -158,7 +169,7 @@ def test_download_b2frame(services, examples_dir, sub_url,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"{sub_url}api/fetch/{ds.path}"
+    assert urlpath == f"{sub_urlbase}api/fetch/{ds.path}"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -168,8 +179,10 @@ def test_download_b2frame(services, examples_dir, sub_url,
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
-def test_index_regular_file(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_index_regular_file(slice_, services, examples_dir, sub_urlbase,
+                            sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['README.md']
 
     # Data contents
@@ -183,9 +196,10 @@ def test_index_regular_file(slice_, services, examples_dir, sub_url, sub_user):
         assert ds.fetch(slice_) == a[slice_]
 
 
-def test_download_regular_file(services, examples_dir, sub_url,
+def test_download_regular_file(services, examples_dir, sub_urlbase,
                                sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['README.md']
     path = ds.download()
     assert path == ds.path
@@ -198,7 +212,7 @@ def test_download_regular_file(services, examples_dir, sub_url,
 
     # Using 2-step download
     urlpath = ds.get_download_url()
-    assert urlpath == f"{sub_url}api/fetch/{ds.path}"
+    assert urlpath == f"{sub_urlbase}api/fetch/{ds.path}"
     data = httpx.get(urlpath,
                      headers={'Cookie': sub_jwt_cookie} if sub_user else None)
     assert data.status_code == 200
@@ -210,14 +224,16 @@ def test_download_regular_file(services, examples_dir, sub_url,
 @pytest.mark.parametrize("name", ['ds-1d.b2nd',
                                   'ds-hello.b2frame',
                                   'README.md'])
-def test_vlmeta(name, services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_vlmeta(name, services, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot[name]
     schunk_meta = ds.meta.get('schunk', ds.meta)
     assert ds.vlmeta is schunk_meta['vlmeta']
 
 
-def test_vlmeta_data(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
+def test_vlmeta_data(services, sub_urlbase, sub_user):
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
+                       user_auth=sub_user)
     ds = myroot['ds-sc-attr.b2nd']
     assert ds.vlmeta == dict(a=1, b="foo", c=123.456)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -46,32 +46,32 @@ def test_roots(services, pub_host, sub_url, sub_jwt_cookie):
 
 
 def test_root(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     assert myroot.name == TEST_CATERVA2_ROOT
-    assert myroot.sub_url == sub_url
+    assert myroot.urlbase == sub_url
 
 
 def test_list(services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     example = examples_dir
     nodes = set(str(f.relative_to(str(example))) for f in example.rglob("*") if f.is_file())
     assert set(myroot.node_list) == nodes
 
 
 def test_file(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     file = myroot['README.md']
     assert file.name == 'README.md'
-    assert file.sub_url == sub_url
+    assert file.urlbase == sub_url
 
 
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(10, 20, 1)])
 def test_index_dataset_frame(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_url == sub_url
+    assert ds.urlbase == sub_url
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -84,10 +84,10 @@ def test_index_dataset_frame(slice_, services, examples_dir, sub_url, sub_user):
 
 
 def test_dataset_step_diff_1(services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['ds-hello.b2frame']
     assert ds.name == 'ds-hello.b2frame'
-    assert ds.sub_url == sub_url
+    assert ds.urlbase == sub_url
     # We don't support step != 1
     with pytest.raises(Exception) as e_info:
         _ = ds[::2]
@@ -97,10 +97,10 @@ def test_dataset_step_diff_1(services, examples_dir, sub_url, sub_user):
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 def test_index_dataset_1d(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['ds-1d.b2nd']
     assert ds.name == 'ds-1d.b2nd'
-    assert ds.sub_url == sub_url
+    assert ds.urlbase == sub_url
 
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -112,7 +112,7 @@ def test_index_dataset_1d(slice_, services, examples_dir, sub_url, sub_user):
                                     slice(1, 5, 1), (slice(None, 10), slice(None, 20))])
 @pytest.mark.parametrize("name", ['dir1/ds-2d.b2nd', 'dir2/ds-4d.b2nd'])
 def test_index_dataset_nd(slice_, name, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot[name]
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
@@ -123,7 +123,7 @@ def test_index_dataset_nd(slice_, name, services, examples_dir, sub_url, sub_use
 @pytest.mark.parametrize("name", ['ds-1d.b2nd', 'dir1/ds-2d.b2nd'])
 def test_download_b2nd(name, services, examples_dir, sub_url,
                        sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot[name]
     path = ds.download()
     assert path == ds.path
@@ -169,7 +169,7 @@ def test_download_b2frame(services, examples_dir, sub_url,
 @pytest.mark.parametrize("slice_", [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None),
                                     slice(1, 5, 1)])
 def test_index_regular_file(slice_, services, examples_dir, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['README.md']
 
     # Data contents
@@ -185,7 +185,7 @@ def test_index_regular_file(slice_, services, examples_dir, sub_url, sub_user):
 
 def test_download_regular_file(services, examples_dir, sub_url,
                                sub_user, sub_jwt_cookie):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['README.md']
     path = ds.download()
     assert path == ds.path
@@ -211,13 +211,13 @@ def test_download_regular_file(services, examples_dir, sub_url,
                                   'ds-hello.b2frame',
                                   'README.md'])
 def test_vlmeta(name, services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot[name]
     schunk_meta = ds.meta.get('schunk', ds.meta)
     assert ds.vlmeta is schunk_meta['vlmeta']
 
 
 def test_vlmeta_data(services, sub_url, sub_user):
-    myroot = cat2.Root(TEST_CATERVA2_ROOT, sub_url=sub_url, user_auth=sub_user)
+    myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_url, user_auth=sub_user)
     ds = myroot['ds-sc-attr.b2nd']
     assert ds.vlmeta == dict(a=1, b="foo", c=123.456)

--- a/caterva2/tests/test_cli.py
+++ b/caterva2/tests/test_cli.py
@@ -23,7 +23,7 @@ def pub_host(services):
 
 
 @pytest.fixture
-def sub_url(services):
+def sub_urlbase(services):
     return services.get_urlbase('subscriber')
 
 
@@ -48,9 +48,9 @@ def test_roots(services, pub_host, sub_user):
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
-def test_url(services, sub_url, sub_user):
+def test_url(services, sub_urlbase, sub_user):
     out = cli(['url', f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'], sub_user=sub_user)
-    assert out == f'{sub_url}api/fetch/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    assert out == f'{sub_urlbase}api/fetch/{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
 
 
 def test_subscribe(services, sub_user):

--- a/caterva2/tests/test_hdf5root.py
+++ b/caterva2/tests/test_hdf5root.py
@@ -27,7 +27,7 @@ def sub_url(services):
 
 @pytest.fixture
 def api_root(sub_url, sub_user):
-    return cat2.Root(TEST_HDF5_ROOT, sub_url=sub_url, user_auth=sub_user)
+    return cat2.Root(TEST_HDF5_ROOT, urlbase=sub_url, user_auth=sub_user)
 
 
 def test_not_unsupported(api_root):

--- a/caterva2/tests/test_hdf5root.py
+++ b/caterva2/tests/test_hdf5root.py
@@ -21,13 +21,13 @@ hdf5root = pytest.importorskip('caterva2.services.hdf5root',
 
 
 @pytest.fixture
-def sub_url(services):
+def sub_urlbase(services):
     return services.get_urlbase('subscriber')
 
 
 @pytest.fixture
-def api_root(sub_url, sub_user):
-    return cat2.Root(TEST_HDF5_ROOT, urlbase=sub_url, user_auth=sub_user)
+def api_root(sub_urlbase, sub_user):
+    return cat2.Root(TEST_HDF5_ROOT, urlbase=sub_urlbase, user_auth=sub_user)
 
 
 def test_not_unsupported(api_root):

--- a/doc/reference/top_level.rst
+++ b/doc/reference/top_level.rst
@@ -44,4 +44,4 @@ Variables listed below as coming from the ``api`` module are available from the 
     api.bro_host_default
     api.pub_host_default
     api.sub_host_default
-    api.sub_url_default
+    api.sub_urlbase_default

--- a/doc/tutorials/independent-services.md
+++ b/doc/tutorials/independent-services.md
@@ -148,8 +148,8 @@ cat2cli roots
 When using the programmatic API, you need to provide the subscriber address explicitly:
 
 ```python
-roots = caterva2.get_roots(sub_url='http://sub.edu.example.org:3126/')
-foo = caterva2.Root('foo', sub_url='http://sub.edu.example.org:3126/')
+roots = caterva2.get_roots(urlbase='http://sub.edu.example.org:3126/')
+foo = caterva2.Root('foo', urlbase='http://sub.edu.example.org:3126/')
 ```
 
 Since parsing TOML is very easy with Python, your API client may just access the needed configuration like this:
@@ -158,5 +158,5 @@ Since parsing TOML is very easy with Python, your API client may just access the
 from tomllib import load as toml_load  # "from tomli" on Python < 3.11
 with open('caterva2.toml', 'rb') as conf_file:
     conf = toml_load(conf_file)
-foo = caterva2.Root('foo', sub_url=conf['subscriber']['url'])
+foo = caterva2.Root('foo', urlbase=conf['subscriber']['url'])
 ```

--- a/doc/utilities/cat2cli.md
+++ b/doc/utilities/cat2cli.md
@@ -13,7 +13,7 @@ Running `cat2cli --help` should provide a list of supported commands that may be
 cat2cli [GENERIC_OPTION...] COMMAND [COMMAND_OPTION...] COMMAND_ARGUMENTS...
 ```
 
-A relevant generic option (besides `--help` itself) is `--subscriber`, which overrides the subscriber URL base used by default.  It should be a slash-terminated HTTP(S) URL, for example `http://sub.edu.example.org:3126/`.
+A relevant generic option (besides `--help` itself) is `--subscriber`, which overrides the base of subscriber URLs used by default.  It should be a slash-terminated HTTP(S) URL, for example `http://sub.edu.example.org:3126/`.
 
 `cat2cli` may use a TOML configuration file (`caterva2.toml` in the current directory unless overridden with the `--conf` option).  Currently, it may only get the subscriber address from there (`http` setting in `[subscriber]` section).  Command-line options override settings read from the configuration file.
 

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -19,7 +19,7 @@ import caterva2 as cat2
 
 
 # Use the demo server
-SUB_URL = 'https://demo.caterva2.net/'
+URLBASE = 'https://demo.caterva2.net/'
 ROOT_NAME = 'example'
 
 user_auth = None
@@ -27,16 +27,16 @@ user_auth = None
 # if the subscriber requires authentication.
 #user_auth = {'username': 'user@example.com', 'password': 'foobar'}
 
-auth_cookie = (cat2.api_utils.get_auth_cookie(SUB_URL, user_auth)
+auth_cookie = (cat2.api_utils.get_auth_cookie(URLBASE, user_auth)
                if user_auth else None)
 
 # Get the list of available roots
-roots = cat2.get_roots(SUB_URL, auth_cookie=auth_cookie)
+roots = cat2.get_roots(URLBASE, auth_cookie=auth_cookie)
 print(roots[ROOT_NAME])
 # Subscribe to a root
-response = cat2.subscribe(ROOT_NAME, SUB_URL, auth_cookie=auth_cookie)
+response = cat2.subscribe(ROOT_NAME, URLBASE, auth_cookie=auth_cookie)
 # Get a handle to the root
-example = cat2.Root(ROOT_NAME, urlbase=SUB_URL, user_auth=user_auth)
+example = cat2.Root(ROOT_NAME, urlbase=URLBASE, user_auth=user_auth)
 # List the datasets in that root
 print(example.node_list)
 # Get a specific dataset

--- a/examples/query_subscriber.py
+++ b/examples/query_subscriber.py
@@ -36,7 +36,7 @@ print(roots[ROOT_NAME])
 # Subscribe to a root
 response = cat2.subscribe(ROOT_NAME, SUB_URL, auth_cookie=auth_cookie)
 # Get a handle to the root
-example = cat2.Root(ROOT_NAME, sub_url=SUB_URL, user_auth=user_auth)
+example = cat2.Root(ROOT_NAME, urlbase=SUB_URL, user_auth=user_auth)
 # List the datasets in that root
 print(example.node_list)
 # Get a specific dataset


### PR DESCRIPTION
This makes the names used in code for subscriber URL bases and dataset paths consistent with those used in Blosc2:

- `sub_url` becomes either `sub_urlbase` (in contexts where several kinds of services may be mentioned) or just `urlbase` (when clearly applying to a subscriber).
- `dataset` and its "name" become `path` in the API.