### PR TITLE
Tomography detection

### DIFF
--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -3,6 +3,7 @@ import pathlib
 
 import blosc2
 
+import numpy
 from fastapi import Depends, FastAPI, Request, responses
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -24,6 +25,19 @@ abspath_and_dataprep = None
 def init(absp_n_datap):
     global abspath_and_dataprep
     abspath_and_dataprep = absp_n_datap
+
+
+def meta_looks_like(meta):
+    if not hasattr(meta, 'dtype'):
+        return None  # not an array
+    dtype = numpy.dtype(meta.dtype)
+    shape = tuple(meta.shape)
+    if (dtype.kind == "u"
+        and (len(shape) == 3  # grayscale
+             or (len(shape) == 4 and shape[-1] in (3, 4)))):  # RGB(A)
+        return contenttype
+    return None
+
 
 @app.get("/display/{path:path}", response_class=HTMLResponse)
 def display(

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -962,6 +962,7 @@ def main():
     app.mount(f"/plugins/{tomography.name}", tomography.app)
     plugins[tomography.contenttype] = tomography
     tomography.init(abspath_and_dataprep)
+    meta_looks_like_funcs.append(tomography.meta_looks_like)
 
     # Run
     global urlbase

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -698,7 +698,8 @@ async def htmx_path_info(
     meta = srv_utils.read_metadata(abspath, cache=cache)
 
     #getattr(meta, 'schunk', meta).vlmeta['contenttype'] = 'tomography'
-    contenttype = getattr(meta, 'schunk', meta).vlmeta.get('contenttype')
+    contenttype = (getattr(meta, 'schunk', meta).vlmeta.get('contenttype')
+                   or meta_looks_like(meta))
     plugin = plugins.get(contenttype)
     if plugin:
         display = {
@@ -911,6 +912,15 @@ async def html_markdown(
 #
 
 plugins = {}
+meta_looks_like_funcs = []
+
+
+def meta_looks_like(meta):
+    for looks_like in meta_looks_like_funcs:
+        if ctype := looks_like(meta):
+            return ctype
+    return None
+
 
 def main():
     conf = utils.get_conf('subscriber', allow_id=True)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -698,10 +698,7 @@ async def htmx_path_info(
     meta = srv_utils.read_metadata(abspath, cache=cache)
 
     #getattr(meta, 'schunk', meta).vlmeta['contenttype'] = 'tomography'
-    if hasattr(getattr(meta, 'schunk', meta), 'vlmeta'):
-        contenttype = getattr(meta, 'schunk', meta).vlmeta.get('contenttype')
-    else:
-        contenttype = None
+    contenttype = getattr(meta, 'schunk', meta).vlmeta.get('contenttype')
     plugin = plugins.get(contenttype)
     if plugin:
         display = {

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -697,7 +697,6 @@ async def htmx_path_info(
     abspath, _ = abspath_and_dataprep(path, user=user)
     meta = srv_utils.read_metadata(abspath, cache=cache)
 
-    #getattr(meta, 'schunk', meta).vlmeta['contenttype'] = 'tomography'
     contenttype = (getattr(meta, 'schunk', meta).vlmeta.get('contenttype')
                    or meta_looks_like(meta))
     plugin = plugins.get(contenttype)


### PR DESCRIPTION
This extends contenttype handling to check against a function that looks at dataset metadata if it can be categorized as some known contenttype, but only if the dataset does not explicitly provide one in its vlmeta. The function can be customized with specific functions coming from plugin modules.

Support is included to detect tomographies automatically, as long as they match those against which display code has been tested (greyscale and RGB(A) ones).