### PR TITLE
Content type detection simplifications

### DIFF
--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -27,7 +27,7 @@ def init(absp_n_datap):
     abspath_and_dataprep = absp_n_datap
 
 
-def meta_looks_like_it(meta):
+def dset_looks_like_it(path, meta):
     if not hasattr(meta, 'dtype'):
         return False  # not an array
     dtype = numpy.dtype(meta.dtype)

--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -27,7 +27,7 @@ def init(absp_n_datap):
     abspath_and_dataprep = absp_n_datap
 
 
-def guess(path, meta):
+def guess(path: pathlib.Path, meta) -> bool:
     if not hasattr(meta, 'dtype'):
         return False  # not an array
     dtype = numpy.dtype(meta.dtype)

--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -28,6 +28,7 @@ def init(absp_n_datap):
 
 
 def guess(path: pathlib.Path, meta) -> bool:
+    """Does dataset (given path and metadata) seem of this content type?"""
     if not hasattr(meta, 'dtype'):
         return False  # not an array
     dtype = numpy.dtype(meta.dtype)

--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -27,7 +27,7 @@ def init(absp_n_datap):
     abspath_and_dataprep = absp_n_datap
 
 
-def dset_looks_like_it(path, meta):
+def guess(path, meta):
     if not hasattr(meta, 'dtype'):
         return False  # not an array
     dtype = numpy.dtype(meta.dtype)

--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -27,16 +27,18 @@ def init(absp_n_datap):
     abspath_and_dataprep = absp_n_datap
 
 
-def meta_looks_like(meta):
+def meta_looks_like_it(meta):
     if not hasattr(meta, 'dtype'):
-        return None  # not an array
+        return False  # not an array
     dtype = numpy.dtype(meta.dtype)
     shape = tuple(meta.shape)
-    if (dtype.kind == "u"
-        and (len(shape) == 3  # grayscale
-             or (len(shape) == 4 and shape[-1] in (3, 4)))):  # RGB(A)
-        return contenttype
-    return None
+    if dtype.kind != "u":
+        return False
+    if len(shape) == 3:
+        return True  # grayscale
+    if len(shape) == 4 and shape[-1] in (3, 4):
+        return True  # RGB(A)
+    return False
 
 
 @app.get("/display/{path:path}", response_class=HTMLResponse)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -921,7 +921,7 @@ async def html_markdown(
 plugins = {}
 
 
-def guess_dset_ctype(path, meta):
+def guess_dset_ctype(path: pathlib.Path, meta) -> str | None:
     for (ctype, plugin) in plugins.items():
         if (hasattr(plugin, 'guess')
                 and plugin.guess(path, meta)):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -919,13 +919,13 @@ async def html_markdown(
 #
 
 plugins = {}
-meta_looks_like_funcs = []
 
 
 def meta_looks_like(meta):
-    for looks_like in meta_looks_like_funcs:
-        if ctype := looks_like(meta):
-            return ctype
+    for plugin in plugins.values():
+        if hasattr(plugin, 'meta_looks_like'):
+            if ctype := plugin.meta_looks_like(meta):
+                return ctype
     return None
 
 
@@ -969,7 +969,6 @@ def main():
     app.mount(f"/plugins/{tomography.name}", tomography.app)
     plugins[tomography.contenttype] = tomography
     tomography.init(abspath_and_dataprep)
-    meta_looks_like_funcs.append(tomography.meta_looks_like)
 
     # Run
     global urlbase

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -923,8 +923,8 @@ plugins = {}
 
 def guess_dset_ctype(path, meta):
     for (ctype, plugin) in plugins.items():
-        if (hasattr(plugin, 'dset_looks_like_it')
-                and plugin.dset_looks_like_it(path, meta)):
+        if (hasattr(plugin, 'guess')
+                and plugin.guess(path, meta)):
             return ctype
     return None
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -922,6 +922,7 @@ plugins = {}
 
 
 def guess_dset_ctype(path: pathlib.Path, meta) -> str | None:
+    """Try to guess dataset's content type (given path and metadata)."""
     for (ctype, plugin) in plugins.items():
         if (hasattr(plugin, 'guess')
                 and plugin.guess(path, meta)):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -703,7 +703,7 @@ async def htmx_path_info(
     meta = srv_utils.read_metadata(abspath, cache=cache)
 
     vlmeta = getattr(getattr(meta, 'schunk', meta), 'vlmeta', {})
-    contenttype = vlmeta.get('contenttype') or meta_looks_like(meta)
+    contenttype = vlmeta.get('contenttype') or guess_dset_ctype(path, meta)
     plugin = plugins.get(contenttype)
     if plugin:
         display = {
@@ -921,10 +921,10 @@ async def html_markdown(
 plugins = {}
 
 
-def meta_looks_like(meta):
+def guess_dset_ctype(path, meta):
     for (ctype, plugin) in plugins.items():
-        if (hasattr(plugin, 'meta_looks_like_it')
-                and plugin.meta_looks_like_it(meta)):
+        if (hasattr(plugin, 'dset_looks_like_it')
+                and plugin.dset_looks_like_it(path, meta)):
             return ctype
     return None
 

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -922,10 +922,10 @@ plugins = {}
 
 
 def meta_looks_like(meta):
-    for plugin in plugins.values():
-        if hasattr(plugin, 'meta_looks_like'):
-            if ctype := plugin.meta_looks_like(meta):
-                return ctype
+    for (ctype, plugin) in plugins.items():
+        if (hasattr(plugin, 'meta_looks_like_it')
+                and plugin.meta_looks_like_it(meta)):
+            return ctype
     return None
 
 


### PR DESCRIPTION
This simplifies the changes in #45 with more understandable names and simpler operation for detecting the content type of a dataset. The detection function in a plugin does just say whether the dataset looks like having the content type implemented by the plugin or not, and there's no need to explicitly register it once the plugin has already been registered.

The plugin's guessing function also gets the dataset path in case it may be useful. For instance, Markdown display machinery could be implemented as a plugin with this (though that is a topic for another PR).

Inspired by <https://github.com/zakirullin/cognitive-load> via @FrancescAlted.