### PR TITLE
Lazy expression subscriber API

### DIFF
--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -14,5 +14,6 @@ __version__ = "0.2.1.dev0"
 
 from .api import (bro_host_default, pub_host_default, sub_host_default,
                   sub_urlbase_default)
-from .api import get_roots, subscribe, get_list, get_info, fetch, download
+from .api import (get_roots, subscribe, get_list, get_info, fetch, download,
+                  lazyexpr)
 from .api import Root, File, Dataset

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -196,7 +196,10 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
 def lazyexpr(name, expression, operands,
              urlbase=sub_urlbase_default, auth_cookie=None):
     # TODO: document
-    raise NotImplementedError  # TODO: implement
+    urlbase, _ = _format_paths(urlbase)
+    expr = dict(name=name, expression=expression, operands=operands)
+    return api_utils.post(f'{urlbase}api/lazyexpr/', expr,
+                          auth_cookie=auth_cookie)
 
 
 class Root:

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -195,7 +195,24 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
 
 def lazyexpr(name, expression, operands,
              urlbase=sub_urlbase_default, auth_cookie=None):
-    # TODO: document
+    """
+    Create a lazy expression dataset in scratch space.
+
+    Parameters
+    ----------
+    name : str
+        The name of the dataset to be created (without extension).
+    expression : str
+        The expression to be evaluated.  It must result in a lazy expression.
+    operands : dictionary of strings mapping to strings
+        The variables used in the expression and which dataset paths they
+        refer to.
+
+    Returns
+    -------
+    str
+        The path of the newly created (or overwritten) dataset.
+    """
     urlbase, _ = _format_paths(urlbase)
     expr = dict(name=name, expression=expression, operands=operands)
     return api_utils.post(f'{urlbase}api/lazyexpr/', expr,

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -193,6 +193,12 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
                                   auth_cookie=auth_cookie)
 
 
+def lazyexpr(name, expression, operands,
+             urlbase=sub_urlbase_default, auth_cookie=None):
+    # TODO: document
+    raise NotImplementedError  # TODO: implement
+
+
 class Root:
     """
     A root is a remote repository that can be subscribed to.

--- a/caterva2/models.py
+++ b/caterva2/models.py
@@ -44,11 +44,19 @@ class Metadata(pydantic.BaseModel):
     dtype: str
     schunk: SChunk
 
+
 class LazyArray(pydantic.BaseModel):
     shape: tuple
     dtype: str
     expression: str
     operands: typing.Dict[str, str]
+
+
+class NewLazyExpr(pydantic.BaseModel):
+    name: str
+    expression: str
+    operands: typing.Dict[str, str]
+
 
 class File(pydantic.BaseModel):
     mtime: float

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -538,7 +538,10 @@ def make_lazy_expr(command: str, operands: dict[str, str],
                    user: db.User) -> str:
     # TODO: document
     if not user:
-        raise fastapi.HTTPException(status_code=401)  # unauthorized
+        raise fastapi.HTTPException(
+            status_code=401,  # unauthorized
+            detail="Creating lazy expressions requires enabling user authentication",
+        )
 
     # Parse command
     result_name, expr = command.split('=')

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -561,7 +561,7 @@ def make_lazy_expr(command: str, operands: dict[str, str],
     path.mkdir(exist_ok=True, parents=True)
     arr.save(urlpath=f'{path / result_name}.b2nd', mode="w")
 
-    return result_name
+    return f'@scratch/{result_name}.b2nd'
 
 
 #
@@ -884,7 +884,7 @@ async def htmx_command(
 
     operands = dict(zip(names, paths))
     try:
-        result_name = make_lazy_expr(command, operands, user)
+        result_path = make_lazy_expr(command, operands, user)
     except (SyntaxError, ValueError):
         return error('Invalid syntax: expected <varname> = <expression>')
     except KeyError as ke:
@@ -893,8 +893,7 @@ async def htmx_command(
     # Redirect to display new dataset
     response = JSONResponse('OK')
 
-    path = f'@scratch/{result_name}.b2nd'
-    url = make_url(request, "html_home", path=path)
+    url = make_url(request, "html_home", path=result_path)
     query = furl.furl(hx_current_url).query
     roots = query.params.getlist('roots')
     if '@scratch' not in roots:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -536,7 +536,29 @@ async def fetch_data(
 
 def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
                   user: db.User) -> str:
-    # TODO: document
+    """
+    Create a lazy expression dataset in scratch space.
+
+    This may raise exceptions if there are problems parsing the dataset name
+    or expression, or if the expression refers to operands which have not been
+    defined.
+
+    Parameters
+    ----------
+    name : str
+        The name of the dataset to be created (without extension).
+    expr : str
+        The expression to be evaluated.  It must result in a lazy expression.
+    operands : dictionary of strings mapping to strings
+        The variables used in the expression and which dataset paths they
+        refer to.
+
+    Returns
+    -------
+    str
+        The path of the newly created (or overwritten) dataset.
+    """
+
     if not user:
         raise fastapi.HTTPException(
             status_code=401,  # unauthorized
@@ -573,7 +595,19 @@ async def lazyexpr(
     expr: models.NewLazyExpr,
     user: db.User = Depends(current_active_user),
 ) -> str:
-    # TODO: document
+    """
+    Create a lazy expression dataset in scratch space.
+
+    The JSON request body must contain a "name" for the dataset to be created
+    (without extension), an "expression" to be evaluated, which must result in
+    a lazy expression, and an "operands" object which maps variable names used
+    in the expression to the dataset paths that they refer to.
+
+    Returns
+    -------
+    str
+        The path of the newly created (or overwritten) dataset.
+    """
 
     def error(msg):
         return fastapi.HTTPException(status_code=400, detail=msg)  # bad request

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -865,13 +865,13 @@ async def htmx_command(
         return error('Invalid syntax: expected <varname> = <expression>')
 
     # Open expression datasets
+    operands = dict(zip(names, paths))
     var_dict = {}
     for var in vars:
         try:
-            key = names.index(var)
-        except ValueError:
+            path = operands[var]
+        except KeyError:
             return error(f'Expression error: {var} is not in the list of available datasets')
-        path = paths[key]
         var_dict[var] = blosc2.open(cache / path, mode="r")
 
     # Create the lazy expression dataset

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -565,6 +565,27 @@ def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
     return f'@scratch/{name}.b2nd'
 
 
+@app.post('/api/lazyexpr/')
+async def lazyexpr(
+    expr: models.NewLazyExpr,
+    user: db.User = Depends(current_active_user),
+) -> str:
+    # TODO: document
+
+    def error(msg):
+        return fastapi.HTTPException(status_code=400, detail=msg)  # bad request
+
+    try:
+        result_path = make_lazyexpr(expr.name, expr.expression, expr.operands,
+                                    user)
+    except (SyntaxError, ValueError) as exc:
+        raise error(f'Invalid name or expression: {exc}')
+    except KeyError as ke:
+        raise error(f'Expression error: {ke.args[0]} is not in the list of available datasets')
+
+    return result_path
+
+
 #
 # HTML interface
 #

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -546,6 +546,8 @@ def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
     # Parse expression
     name = name.strip()
     expr = expr.strip()
+    if not name or not expr:
+        raise ValueError("Name or expression should not be empty")
     vars = ne.NumExpr(expr).input_names
 
     # Open expression datasets

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -534,7 +534,7 @@ async def fetch_data(
                                        media_type='application/octet-stream')
 
 
-def make_lazy_expr(command: str, operands: dict[str, str],
+def make_lazy_expr(name: str, expr: str, operands: dict[str, str],
                    user: db.User) -> str:
     # TODO: document
     if not user:
@@ -543,9 +543,8 @@ def make_lazy_expr(command: str, operands: dict[str, str],
             detail="Creating lazy expressions requires enabling user authentication",
         )
 
-    # Parse command
-    result_name, expr = command.split('=')
-    result_name = result_name.strip()
+    # Parse expression
+    name = name.strip()
     expr = expr.strip()
     vars = ne.NumExpr(expr).input_names
 
@@ -559,9 +558,9 @@ def make_lazy_expr(command: str, operands: dict[str, str],
     arr = eval(expr, var_dict)
     path = scratch / str(user.id)
     path.mkdir(exist_ok=True, parents=True)
-    arr.save(urlpath=f'{path / result_name}.b2nd', mode="w")
+    arr.save(urlpath=f'{path / name}.b2nd', mode="w")
 
-    return f'@scratch/{result_name}.b2nd'
+    return f'@scratch/{name}.b2nd'
 
 
 #
@@ -884,7 +883,8 @@ async def htmx_command(
 
     operands = dict(zip(names, paths))
     try:
-        result_path = make_lazy_expr(command, operands, user)
+        result_name, expr = command.split('=')
+        result_path = make_lazy_expr(result_name, expr, operands, user)
     except (SyntaxError, ValueError):
         return error('Invalid syntax: expected <varname> = <expression>')
     except KeyError as ke:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -534,8 +534,8 @@ async def fetch_data(
                                        media_type='application/octet-stream')
 
 
-def make_lazy_expr(name: str, expr: str, operands: dict[str, str],
-                   user: db.User) -> str:
+def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
+                  user: db.User) -> str:
     # TODO: document
     if not user:
         raise fastapi.HTTPException(
@@ -884,7 +884,7 @@ async def htmx_command(
     operands = dict(zip(names, paths))
     try:
         result_name, expr = command.split('=')
-        result_path = make_lazy_expr(result_name, expr, operands, user)
+        result_path = make_lazyexpr(result_name, expr, operands, user)
     except (SyntaxError, ValueError):
         return error('Invalid syntax: expected <varname> = <expression>')
     except KeyError as ke:

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -45,6 +45,30 @@ def test_roots(services, pub_host, sub_urlbase, sub_jwt_cookie):
     assert roots[TEST_CATERVA2_ROOT]['http'] == pub_host
 
 
+def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
+    if not sub_jwt_cookie:
+        pytest.skip("authentication support needed")
+
+    opnm = 'ds'
+    oppt = f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    expression = f'{opnm} + 0'
+    operands = {opnm: oppt}
+    lxname = 'my_expr'
+
+    cat2.subscribe(TEST_CATERVA2_ROOT, sub_urlbase,
+                   auth_cookie=sub_jwt_cookie)
+    opinfo = cat2.get_info(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
+                           auth_cookie=sub_jwt_cookie)
+    assert lxpath == f'@scratch/{lxname}.b2nd'
+    lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+
+    assert lxinfo['shape'] == opinfo['shape']
+    assert lxinfo['dtype'] == opinfo['dtype']
+    assert lxinfo['expression'] == expression
+    assert lxinfo['operands'] == operands
+
+
 def test_root(services, sub_urlbase, sub_user):
     myroot = cat2.Root(TEST_CATERVA2_ROOT, urlbase=sub_urlbase,
                        user_auth=sub_user)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -61,12 +61,18 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
     lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
                            auth_cookie=sub_jwt_cookie)
     assert lxpath == f'@scratch/{lxname}.b2nd'
-    lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
 
+    # Check result metadata.
+    lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
     assert lxinfo['shape'] == opinfo['shape']
     assert lxinfo['dtype'] == opinfo['dtype']
     assert lxinfo['expression'] == f'({expression})'.replace(opnm, 'o0')
     assert lxinfo['operands'] == dict(o0=operands[opnm])
+
+    # Check result data.
+    a = cat2.fetch(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    b = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    np.testing.assert_array_equal(a[:], b[:])
 
 
 def test_root(services, sub_urlbase, sub_user):

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -65,8 +65,8 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
 
     assert lxinfo['shape'] == opinfo['shape']
     assert lxinfo['dtype'] == opinfo['dtype']
-    assert lxinfo['expression'] == expression
-    assert lxinfo['operands'] == operands
+    assert lxinfo['expression'] == f'({expression})'.replace(opnm, 'o0')
+    assert lxinfo['operands'] == dict(o0=operands[opnm])
 
 
 def test_root(services, sub_urlbase, sub_user):

--- a/doc/reference/top_level.rst
+++ b/doc/reference/top_level.rst
@@ -32,6 +32,16 @@ Fetch / download datasets
     download
 
 
+Evaluating expressions
+----------------------
+
+.. autosummary::
+   :toctree: autofiles/top_level/
+   :nosignatures:
+
+    lazyexpr
+
+
 Utility variables
 -----------------
 

--- a/doc/tutorials/API.md
+++ b/doc/tutorials/API.md
@@ -79,6 +79,26 @@ caterva2.download('foo/dir1/ds-2d.b2nd')
 
 The call downloads the dataset as a file and returns its local path `PosixPath('foo/dir1/ds-2d.b2nd')`, which should be similar to the dataset name.
 
+### Evaluating expressions
+
+The Caterva2 subscriber also allows you to create so-called "lazy expressions" (lazyexprs) where operands are the array datasets accessible via the subscriber.  These expressions get stored in the user's own scratch space (an always-subscribed pseudo-root named `@scratch`), thus working with them requires user authentication.
+
+Lazy expressions are very cheap to create as that operation only requires knowing the metadata of the involved operands.  The resulting data is not computed on creation, it only takes place at the subscriber when you request access to the data itself (e.g. via fetch or download operations).
+
+This code creates a lazyexpr named `plusone` from the 2D dataset used above (check the note further above on how to get the `auth_cookie`):
+
+```python
+caterva2.lazyexpr('plusone', 'x + 1', {'x': 'foo/dir1/ds-2d.b2nd'},
+                  auth_cookie=...)
+```
+
+The path of the new dataset is returned: `@scratch/plusone.b2nd`.  Now you can access it as a normal dataset, e.g.:
+
+```python
+caterva2.fetch('@scratch/plusone.b2nd', slice_='0:2, 4:8',
+               auth_cookie=...)
+```
+
 ## The object-oriented client API
 
 The top level client API is simple but not very pythonic.  Fortunately, Caterva2 also provides a light and concise object-oriented client API (fully described in [](ref-API-Root), [](ref-API-File) and  [](ref-API-Dataset)), similar to that of h5py.


### PR DESCRIPTION
This adds an `/api/lazyexpr/` endpoint to the subscriber API where an expression may be POSTed to create a new lazy expression dataset under scratch space, much as it was already possible via the web client. In fact, they both share the same underlying code now.

It also adds some extra checks that were missing in the original lazyexpr creation code.

A top-level client API function has been added, as well as tests and a short section in the API tutorial.