### PR TITLE
Add usage of blosc2.ProxySChunk

### DIFF
--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -51,7 +51,7 @@ def parse_slice(string):
             segment = slice(*map(lambda x: int(x.strip()) if x.strip() else None, segment.split(':')))
         obj.append(segment)
 
-    return tuple(obj)
+    return tuple(obj) if len(obj) > 1 else obj[0]
 
 
 def get_auth_cookie(urlbase, user_auth):

--- a/caterva2/services/plugins/tomography/__init__.py
+++ b/caterva2/services/plugins/tomography/__init__.py
@@ -10,6 +10,7 @@ from fastapi.templating import Jinja2Templates
 
 from .. import current_active_user
 from ...subscriber import db
+from ...sub import open_b2
 
 
 app = FastAPI()
@@ -59,7 +60,7 @@ def display(
 ):
 
     abspath, _ = abspath_and_dataprep(path, user=user)
-    arr = blosc2.open(abspath)
+    arr = open_b2(abspath, path)
 
     base = f"/plugins/{name}"
     context = {
@@ -72,10 +73,9 @@ def display(
 async def __get_image(path, i, user):
     from PIL import Image
 
-    # TODO: This accepts a slice, pass it in.
-    abspath, dataprep = abspath_and_dataprep(path, user=user)
-    await dataprep()
-    arr = blosc2.open(abspath)
+    # Alternatively, call abspath_and_dataprep with the corresponding slice to download data async
+    abspath, _ = abspath_and_dataprep(path, user=user)
+    arr = open_b2(abspath, path)
 
     img = arr[i,:]
     return Image.fromarray(img)

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -204,30 +204,6 @@ def compress(data, dst=None):
     return schunk
 
 
-def open_b2(abspath):
-    suffix = abspath.suffix
-    if suffix == '.b2nd':
-        array = blosc2.open(abspath)
-        schunk = getattr(array, 'schunk', None)  # may be lazy
-    elif suffix == '.b2frame':
-        array = None
-        schunk = blosc2.open(abspath)
-    elif suffix == '.b2':
-        array = None
-        schunk = blosc2.open(abspath)
-    else:
-        raise NotImplementedError()
-
-    return array, schunk
-
-
-def chunk_is_available(schunk, nchunk):
-    # Blosc2 flags are at offset 31
-    # (see https://github.com/Blosc/c-blosc2/blob/main/README_CHUNK_FORMAT.rst)
-    flag = (schunk.get_lazychunk(nchunk)[31] & 0b01110000) >> 4
-    return flag != blosc2.SpecialValue.UNINIT.value
-
-
 def iterchunk(chunk):
     # TODO Yield block by block
     yield chunk

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -58,6 +58,9 @@ urlbase = None
 
 
 class PubDataset(blosc2.ProxySource):
+    """
+    Class for getting chunks from a dataset on a publisher service.
+    """
     def __init__(self, abspath, path, metadata=None):
         self.path = pathlib.Path(path)
         if metadata is not None:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -57,7 +57,7 @@ locks = {}
 urlbase = None
 
 
-class PubDataset:
+class PubDataset(blosc2.ProxySource):
     def __init__(self, abspath, path, metadata=None):
         self.path = pathlib.Path(path)
         if metadata is not None:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -124,9 +124,6 @@ async def _get_chunk(path, nchunk, user=None):
         chunk = b''.join(buffer)
         return chunk
 
-async def download_chunk(path, schunk, nchunk):
-    chunk = await _get_chunk(path, nchunk)
-    schunk.update_chunk(nchunk, chunk)
 
 async def new_root(data, topic):
     logger.info(f'NEW root {topic} {data=}')

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -441,10 +441,7 @@ async def partial_download(abspath, path, slice_=None):
     lock = locks.setdefault(path, asyncio.Lock())
     async with lock:
         proxy = open_b2(abspath, path)
-        if slice_:
-            proxy.fetch(slice_)
-        else:
-            proxy.fetch()
+        proxy.fetch(slice_)
 
 
 async def download_expr_deps(expr):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -141,7 +141,8 @@ async def updated_dataset(data, topic):
         if abspath.is_file():
             abspath.unlink()
     else:
-        init_b2(abspath, name, metadata)
+        key = f'{name}/{relpath}'
+        init_b2(abspath, key, metadata)
 
 
 def init_b2(abspath, path, metadata):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -85,9 +85,6 @@ class PubDataset:
                 self.abspath.parent.mkdir(exist_ok=True, parents=True)
 
     def get_chunk(self, nchunk):
-        # # TODO: auth_token???
-        # # response = httpx.get(url, params=params, headers=headers, timeout=timeout)
-
         root, name = self.path.parts[0], pathlib.Path(*self.path.parts[1:])
         host = database.roots[root].http
         url = f'http://{host}/api/download/{name}'

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -206,7 +206,7 @@ def follow(name: str):
         response.raise_for_status()
         metadata = response.json()
 
-        # Save metadata
+        # Save metadata and create ProxySChunk
         abspath = rootdir / relpath
         init_b2(abspath, key, metadata)
 
@@ -444,7 +444,7 @@ async def partial_download(abspath, path, slice_=None):
     lock = locks.setdefault(path, asyncio.Lock())
     async with lock:
         proxy = open_b2(abspath, path)
-        proxy.fetch(slice_)
+        await proxy.afetch(slice_)
 
 
 async def download_expr_deps(expr):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -141,7 +141,16 @@ async def updated_dataset(data, topic):
         if abspath.is_file():
             abspath.unlink()
     else:
-        srv_utils.init_b2(abspath, metadata)
+        init_b2(abspath, name, metadata)
+
+
+def init_b2(abspath, path, metadata):
+    dataset = PubDataset(abspath, path, metadata)
+    schunk_meta = metadata.get('schunk', metadata)
+    vlmeta = {}
+    for k, v in schunk_meta['vlmeta'].items():
+        vlmeta[k] = v
+    blosc2.ProxySChunk(dataset, urlpath=dataset.abspath, vlmeta=vlmeta, caterva2_env=True)
 
 
 #
@@ -186,12 +195,7 @@ def follow(name: str):
 
         # Save metadata
         abspath = rootdir / relpath
-        dataset = PubDataset(abspath, key, metadata)
-        schunk_meta = metadata.get('schunk', metadata)
-        vlmeta = {}
-        for k, v in schunk_meta['vlmeta'].items():
-            vlmeta[k] = v
-        blosc2.ProxySChunk(dataset, urlpath=dataset.abspath, vlmeta=vlmeta, caterva2_env=True)
+        init_b2(abspath, key, metadata)
 
         # Save etag
         database.etags[key] = response.headers['etag']

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -229,7 +229,7 @@ def follow(name: str):
 #
 
 def user_auth_enabled():
-    return bool(os.environ.get(users.SECRET_TOKEN_ENVVAR))
+    return bool(os.environ.get('CATERVA2_AUTH_SECRET'))
 
 
 current_active_user = (users.current_active_user if user_auth_enabled()

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -156,7 +156,7 @@ def init_b2(abspath, path, metadata):
     vlmeta = {}
     for k, v in schunk_meta['vlmeta'].items():
         vlmeta[k] = v
-    blosc2.ProxySChunk(dataset, urlpath=dataset.abspath, vlmeta=vlmeta, caterva2_env=True)
+    blosc2.Proxy(dataset, urlpath=dataset.abspath, vlmeta=vlmeta, caterva2_env=True)
 
 
 def open_b2(abspath, path=None):
@@ -166,7 +166,7 @@ def open_b2(abspath, path=None):
     dataset = PubDataset(abspath, path)
     container = blosc2.open(abspath)
     # No need to pass caterva2_env=True since _cache has already been created
-    return blosc2.ProxySChunk(dataset, _cache=container)
+    return blosc2.Proxy(dataset, _cache=container)
 
 
 #
@@ -209,7 +209,7 @@ def follow(name: str):
         response.raise_for_status()
         metadata = response.json()
 
-        # Save metadata and create ProxySChunk
+        # Save metadata and create Proxy
         abspath = rootdir / relpath
         init_b2(abspath, key, metadata)
 
@@ -671,7 +671,7 @@ def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
         else:
             abspath = cache / path
 
-        # LazyExpr operands cannot be ProxySChunk, get a NDArray instead
+        # LazyExpr operands cannot be Proxy, get a NDArray instead
         var_dict[var] = open_b2(abspath)
 
     # Create the lazy expression dataset

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -59,7 +59,7 @@ urlbase = None
 
 class PubDataset:
     def __init__(self, abspath, path, metadata=None):
-        self.path = path
+        self.path = pathlib.Path(path)
         if metadata is not None:
             suffix = abspath.suffix
             if suffix == '.b2nd':

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -665,7 +665,7 @@ def make_lazyexpr(name: str, expr: str, operands: dict[str, str],
         else:
             abspath = cache / path
 
-        var_dict[var] = blosc2.open(abspath, mode="r")
+        var_dict[var] = open_b2(abspath)
 
     # Create the lazy expression dataset
     arr = eval(expr, var_dict)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -467,31 +467,6 @@ async def partial_download(abspath, path, slice_=None):
         await proxy.afetch(slice_)
 
 
-async def download_expr_deps(expr):
-    """
-    Download the datasets that the lazy expression dataset depends on.
-
-    Parameters
-    ----------
-    abspath : pathlib.Path
-        The absolute path to the lazy expression dataset.
-
-    Returns
-    -------
-    None
-        When finished, expression dependencies are available in cache.
-    """
-    coroutines = []
-    for ndarr in expr.operands.values():
-        relpath = srv_utils.get_relpath(ndarr, cache, scratch)
-        if relpath.parts[0] != '@scratch':
-            abspath = pathlib.Path(ndarr.schunk.urlpath)
-            coroutine = partial_download(abspath, str(relpath))
-            coroutines.append(coroutine)
-
-    await asyncio.gather(*coroutines)
-
-
 def abspath_and_dataprep(path: pathlib.Path,
                          slice_: (tuple | None) = None,
                          user: (db.User | None) = None) -> tuple[

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -156,7 +156,10 @@ def init_b2(abspath, path, metadata):
     blosc2.ProxySChunk(dataset, urlpath=dataset.abspath, vlmeta=vlmeta, caterva2_env=True)
 
 
-def open_b2(abspath, path):
+def open_b2(abspath, path=None):
+    if path is None:
+        # Container in scratch
+        return blosc2.open(abspath)
     dataset = PubDataset(abspath, path)
     container = blosc2.open(abspath)
     # No need to pass caterva2_env=True since _cache has already been created
@@ -600,7 +603,8 @@ async def get_chunk(
     # TODO: Use caching via ProxySChunk, mind locking cache file.
     abspath, _ = abspath_and_dataprep(path, user=user)
     if user and path.parts[0] == '@scratch':
-        array, schunk = srv_utils.open_b2(abspath)
+        container = open_b2(abspath)
+        schunk = getattr(container, 'schunk', container)
         # TODO: Support lazy expressions.
         chunk = schunk.get_chunk(nchunk)  # TODO: async?
     else:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -600,15 +600,15 @@ async def get_chunk(
     nchunk: int,
     user: db.User = Depends(current_active_user),
 ):
-    abspath, dataprep = abspath_and_dataprep(path, user=user)
+    abspath, _ = abspath_and_dataprep(path, user=user)
     lock = locks.setdefault(path, asyncio.Lock())
     async with lock:
         if user and path.parts[0] == '@scratch':
             container = open_b2(abspath)
             schunk = getattr(container, 'schunk', container)
             if 'LazyArray' in schunk.meta:
-                # TODO: only evaluate the requested chunk
-                await dataprep()
+                # TODO: Support this
+                raise NotImplementedError
             chunk = schunk.get_chunk(nchunk)
         else:
             sub_dset = PubDataset(abspath, path)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -85,11 +85,11 @@ class PubDataset:
                 self.abspath.parent.mkdir(exist_ok=True, parents=True)
 
     def _get_request_args(self, nchunk):
-        root, name = self.path.parts[0], pathlib.Path(*self.path.parts[1:])
-        host = database.roots[root].http
-        url = f'http://{host}/api/download/{name}'
-        params = {'nchunk': nchunk}
-        return dict(url=url, params=params, timeout=5)
+        root, *name = self.path.parts
+        root = database.roots[root]
+        name = pathlib.Path(*name)
+        return dict(url=f'http://{root.http}/api/download/{name}',
+                    params={'nchunk': nchunk}, timeout=5)
 
     def get_chunk(self, nchunk):
         req_args = self._get_request_args(nchunk)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -69,6 +69,8 @@ class PubDataset:
                 self.blocks = metadata.blocks
                 dtype = metadata.dtype
                 if metadata.dtype.startswith('['):
+                    # TODO: eval is dangerous, but we mostly trust the metadata
+                    # This is a list, so we need to convert it to a string
                     dtype = eval(dtype)
                 self.dtype = np.dtype(dtype)
             else:

--- a/caterva2/services/subscriber/db.py
+++ b/caterva2/services/subscriber/db.py
@@ -13,10 +13,9 @@ Used for user authentication (for the moment), based on FastAPI Users example:
 https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
 
 The database should only be used if a (non-empty) secret token for the
-management of users is set in the environment variable named by
-`caterva2.services.subscriber.users.SECRET_TOKEN_ENVVAR`.
+management of users is set in the 'CATERVA2_AUTH_SECRET' environment variable.
 
-The database will be stored in SQLite format inside of the state directory
+The database will be stored in SQLite format inside the state directory
 given to `create_db_and_tables()`.
 """
 

--- a/caterva2/services/subscriber/users.py
+++ b/caterva2/services/subscriber/users.py
@@ -13,8 +13,7 @@ Used for user authentication (for the moment), based on FastAPI Users example:
 https://fastapi-users.github.io/fastapi-users/latest/configuration/full-example/
 
 The database should only be used if a (non-empty) secret token for the
-management of users is set in the environment variable named by
-`SECRET_TOKEN_ENVVAR`.
+management of users is set in the 'CATERVA2_AUTH_SECRET' environment variable.
 """
 
 import functools
@@ -34,17 +33,14 @@ from fastapi_users.db import SQLAlchemyUserDatabase
 from .db import User, get_user_db
 
 
-SECRET_TOKEN_ENVVAR = 'CATERVA2_AUTH_SECRET'
-
-
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     @functools.cached_property
     def reset_password_token_secret(self):
-        return os.environ.get(SECRET_TOKEN_ENVVAR)
+        return os.environ.get('CATERVA2_AUTH_SECRET')
 
     @functools.cached_property
     def verification_token_secret(self):
-        return os.environ.get(SECRET_TOKEN_ENVVAR)
+        return os.environ.get('CATERVA2_AUTH_SECRET')
 
     # TODO: Replace with actual functionality;
     # support user verification, allow password reset and user deletion.
@@ -77,7 +73,7 @@ def get_jwt_strategy() -> JWTStrategy:
     # The token itself is valid for an hour, even after an explicit logout
     # (however the cookie transport would delete the cookie anyway).
     lifetime_seconds = 3600 * 12
-    return JWTStrategy(secret=os.environ.get(SECRET_TOKEN_ENVVAR),
+    return JWTStrategy(secret=os.environ.get('CATERVA2_AUTH_SECRET'),
                        lifetime_seconds=lifetime_seconds)
 
 

--- a/caterva2/tests/sub_auth.py
+++ b/caterva2/tests/sub_auth.py
@@ -23,7 +23,7 @@ UserAuth = collections.namedtuple('UserAuth', ['username', 'password'])
 
 
 def sub_auth_enabled():
-    return bool(os.environ.get(sub_users.SECRET_TOKEN_ENVVAR))
+    return bool(os.environ.get('CATERVA2_AUTH_SECRET'))
 
 
 def make_sub_user(services):


### PR DESCRIPTION
To properly run this branch, the wheel from the `CacheSChunk` branch in python-blosc2 must be installed.
This PR adds the usage of the class blosc2.ProxySChunk. 
With these changes, every published dataset will be treated as a ProxySChunk. To access its data the partial_download func must be called to first initialize the cache.
When the files are in scratch, such as uploaded files or LazyExpr files, they are treated like a blosc2.SChunk or blosc2.NDarray instead.