### PR TITLE
Support for Unix Domain Sockets (wip)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ install:
 	${BIN}/pip install -e .[tests]
 
 bro:
-	${BIN}/python3 -m caterva2.services.bro --statedir=var/bro
+	${BIN}/python3 -m caterva2.services.bro
 
 pub-dir:
-	${BIN}/python3 -m caterva2.services.pub --statedir=var/pub-dir foo root-example --http=localhost:8010
+	${BIN}/python3 -m caterva2.services.pub --id dir
 
 pub-color:
-	${BIN}/python3 -m caterva2.services.pub --statedir=var/pub-color color numbers-default.h5 --http=localhost:8011
+	${BIN}/python3 -m caterva2.services.pub --id color
 
 pub-gris:
-	${BIN}/python3 -m caterva2.services.pub --statedir=var/pub-gris gris numbers-10x-gris-3d.h5 --http=localhost:8012
+	${BIN}/python3 -m caterva2.services.pub --id gris
 
 sub:
-	BLOSC_TRACE=1 ${BIN}/python3 -m caterva2.services.sub --statedir=var/sub
+	BLOSC_TRACE=1 ${BIN}/python3 -m caterva2.services.sub

--- a/caterva2/services/bro.py
+++ b/caterva2/services/bro.py
@@ -13,7 +13,6 @@ import typing
 from fastapi import FastAPI
 from fastapi.routing import APIRouter
 from fastapi_websocket_pubsub import PubSubEndpoint
-import uvicorn
 
 # Project
 from caterva2 import utils, models
@@ -62,8 +61,7 @@ def main():
     print(database.data)
 
     # Run
-    host, port = args.http
-    uvicorn.run(app, host=host, port=port)
+    utils.uvicorn_run(app, args)
 
 
 if __name__ == '__main__':

--- a/caterva2/services/pub.py
+++ b/caterva2/services/pub.py
@@ -14,7 +14,6 @@ import logging
 # Requirements
 import blosc2
 from fastapi import FastAPI, Response, responses
-import uvicorn
 
 # Project
 from caterva2 import utils, api_utils, models
@@ -219,13 +218,11 @@ def main():
     database = srv_utils.Database(statedir / 'db.json', model)
 
     # Register
-    host, port = args.http
-    data = {'name': name, 'http': f'{host}:{port}'}
-    api_utils.post(f'http://{broker}/api/roots', json=data)
+    data = {'name': name, 'http': args.http}
+    api_utils.post('/api/roots', json=data, server=args.broker)
 
     # Run
-    host, port = args.http
-    uvicorn.run(app, host=host, port=port)
+    utils.uvicorn_run(app, args)
 
 
 if __name__ == '__main__':

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -88,7 +88,7 @@ class PubDataset(blosc2.ProxySource):
             if self.abspath is not None:
                 self.abspath.parent.mkdir(exist_ok=True, parents=True)
 
-    def _get_client_and_request_args(self, nchunk, return_async_client):
+    def _get_request_args(self, nchunk, return_async_client):
         root, *name = self.path.parts
         root = database.roots[root]
         name = pathlib.Path(*name)
@@ -99,7 +99,7 @@ class PubDataset(blosc2.ProxySource):
         return client, args
 
     def get_chunk(self, nchunk):
-        client, req_args = self._get_client_and_request_args(nchunk, return_async_client=False)
+        client, req_args = self._get_request_args(nchunk, return_async_client=False)
 
         response = client.get(**req_args)
         response.raise_for_status()
@@ -107,7 +107,7 @@ class PubDataset(blosc2.ProxySource):
         return chunk
 
     async def aget_chunk(self, nchunk):
-        client, req_args = self._get_client_and_request_args(nchunk, return_async_client=True)
+        client, req_args = self._get_request_args(nchunk, return_async_client=True)
 
         async with client.stream('GET', **req_args) as resp:
             buffer = []

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -31,7 +31,6 @@ import httpx
 import markdown
 import numexpr as ne
 import numpy as np
-import uvicorn
 
 # Project
 from caterva2 import utils, api_utils, models
@@ -89,25 +88,27 @@ class PubDataset(blosc2.ProxySource):
             if self.abspath is not None:
                 self.abspath.parent.mkdir(exist_ok=True, parents=True)
 
-    def _get_request_args(self, nchunk):
+    def _get_client_and_request_args(self, nchunk, return_async_client):
         root, *name = self.path.parts
         root = database.roots[root]
         name = pathlib.Path(*name)
-        return dict(url=f'http://{root.http}/api/download/{name}',
-                    params={'nchunk': nchunk}, timeout=5)
+
+        url = f'/api/download/{name}'
+        client, url = api_utils.get_client_and_url(root.http, url, return_async_client=return_async_client)
+        args = dict(url=url, params={'nchunk': nchunk}, timeout=5)
+        return client, args
 
     def get_chunk(self, nchunk):
-        req_args = self._get_request_args(nchunk)
+        client, req_args = self._get_client_and_request_args(nchunk, return_async_client=False)
 
-        response = httpx.get(**req_args)
+        response = client.get(**req_args)
         response.raise_for_status()
         chunk = response.content
         return chunk
 
     async def aget_chunk(self, nchunk):
-        req_args = self._get_request_args(nchunk)
+        client, req_args = self._get_client_and_request_args(nchunk, return_async_client=True)
 
-        client = httpx.AsyncClient()
         async with client.stream('GET', **req_args) as resp:
             buffer = []
             async for chunk in resp.aiter_bytes():
@@ -207,7 +208,7 @@ def follow(name: str):
 
     # Get list of datasets
     try:
-        data = api_utils.get(f'http://{root.http}/api/list')
+        data = api_utils.get('/api/list', server=root.http)
     except httpx.ConnectError:
         return
 
@@ -219,7 +220,9 @@ def follow(name: str):
         headers = None if val is None else {'If-None-Match': val}
 
         # Call API
-        response = httpx.get(f'http://{root.http}/api/info/{relpath}', headers=headers)
+        response = api_utils.get(f'/api/info/{relpath}', headers=headers,
+                                 server=root.http, raise_for_status=False,
+                                 return_response=True)
         if response.status_code == 304:
             continue
 
@@ -278,7 +281,7 @@ async def lifespan(app: FastAPI):
 
     # Initialize roots from the broker
     try:
-        data = api_utils.get(f'http://{broker}/api/roots')
+        data = api_utils.get('/api/roots', server=broker)
     except httpx.ConnectError:
         logger.warning('Broker not available')
         client = None
@@ -1205,9 +1208,8 @@ def main():
 
     # Run
     global urlbase
-    host, port = args.http
     urlbase = args.url
-    uvicorn.run(app, host=host, port=port)
+    utils.uvicorn_run(app, args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It works except for websockets, because these are not supported by fastapi_websocket_pubsub / fastapi_websocket_rpc 
c.f. https://github.com/permitio/fastapi_websocket_rpc/issues/41

This means that the publishers and subscribers can listen to unix sockets, but not yet the broker.