### PR TITLE
Make the size of the file to fit comfortably in dataset view

### DIFF
--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -16,7 +16,6 @@ import typing
 import blosc2
 import fastapi
 import fastapi_websocket_pubsub
-import numpy as np
 import safer
 
 # Project

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -324,6 +324,16 @@ async def lifespan(app: FastAPI):
     if client is not None:
         await srv_utils.disconnect_client(client)
 
+# Visualize the size of a file on a compact and human-readable format
+def custom_filesizeformat(value):
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+        if value < 1024.0:
+            if unit == 'B':
+                return f"{value:.0f} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PB"
+
 
 app = FastAPI(lifespan=lifespan)
 if user_auth_enabled():
@@ -339,6 +349,7 @@ if user_auth_enabled():
     # TODO: Support user verification, allow password reset and user deletion.
 app.mount("/static", StaticFiles(directory=BASE_DIR / "static"))
 templates = Jinja2Templates(directory=BASE_DIR / "templates")
+templates.env.filters['filesizeformat'] = custom_filesizeformat
 
 
 @app.get('/api/roots')

--- a/caterva2/services/templates/path_list.html
+++ b/caterva2/services/templates/path_list.html
@@ -31,7 +31,7 @@
                 {% endif %}
                 <a href="{{dataset.url}}"
                    class="input-group-text text-decoration-none"
-                   style="width: 75%"
+                   style="width: 70%"
                    hx-get="/htmx/path-info/{{dataset.path}}"
                    hx-target="#meta"
                    hx-indicator="#meta-wrapper .htmx-indicator"
@@ -39,7 +39,7 @@
                    >
                     {{dataset.path}}
                 </a>
-                <span class="input-group-text" style="width: 15%">
+                <span class="input-group-text" style="width: 20%">
                     {{ dataset.size|filesizeformat }}
                 </span>
             </div>


### PR DESCRIPTION
With this, filesizes are viewed as: 
<img width="655" alt="image" src="https://github.com/user-attachments/assets/069cc595-ed6c-4777-835d-94d19e878057">

Perhaps we can stretch the view a bit more, but I am unsure whether this can affect other things.

Fixes #60 