### PR TITLE
Support get_chunk for LazyExpr

### DIFF
--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -14,6 +14,6 @@ __version__ = "2024.07.01"
 
 from .api import (bro_host_default, pub_host_default, sub_host_default,
                   sub_urlbase_default)
-from .api import (get_roots, subscribe, get_list, get_info, fetch, download,
+from .api import (get_roots, subscribe, get_chunk, get_list, get_info, fetch, download,
                   lazyexpr)
 from .api import Root, File, Dataset

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -167,6 +167,32 @@ def fetch(path, urlbase=sub_urlbase_default, slice_=None,
     return data
 
 
+def get_chunk(path, nchunk, urlbase=sub_urlbase_default, auth_cookie=None):
+    """
+    Get the unidimensional compressed chunk of a dataset.
+
+    Parameters
+    ----------
+    path : str
+        The path of the dataset.
+    nchunk : int
+        The unidimensional chunk id to get.
+    urlbase : str
+        The base of URLs (slash-terminated) of the subscriber to query.
+    auth_cookie : str
+        An optional HTTP cookie for authorizing access.
+
+    Returns
+    -------
+    bytes obj
+        The compressed chunk.
+    """
+    urlbase, path = _format_paths(urlbase, path)
+    data = api_utils._xget(f'{urlbase}api/chunk/{path}', {'nchunk': nchunk},
+                           auth_cookie=auth_cookie)
+    return data.content
+
+
 def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
     """
     Download a dataset to storage.

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -602,10 +602,11 @@ async def get_chunk(
         if user and path.parts[0] == '@scratch':
             container = open_b2(abspath, path)
             if isinstance(container, blosc2.LazyArray):
-                # TODO: Support this
-                raise NotImplementedError
-            schunk = getattr(container, 'schunk', container)
-            chunk = schunk.get_chunk(nchunk)
+                # We do not support LazyUDF in Caterva2. In case we do, this would have to be changed
+                chunk = container.get_chunk(nchunk)
+            else:
+                schunk = getattr(container, 'schunk', container)
+                chunk = schunk.get_chunk(nchunk)
         else:
             sub_dset = PubDataset(abspath, path)
             chunk = await sub_dset.aget_chunk(nchunk)

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -65,6 +65,67 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
 
     opnm = 'ds'
     oppt = f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    expression = f'{opnm} + 0'
+    operands = {opnm: oppt}
+    lxname = 'my_expr'
+
+    cat2.subscribe(TEST_CATERVA2_ROOT, sub_urlbase,
+                   auth_cookie=sub_jwt_cookie)
+    opinfo = cat2.get_info(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
+                           auth_cookie=sub_jwt_cookie)
+    assert lxpath == f'@scratch/{lxname}.b2nd'
+
+    # Check result metadata.
+    lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    assert lxinfo['shape'] == opinfo['shape']
+    assert lxinfo['dtype'] == opinfo['dtype']
+    assert lxinfo['expression'] == f'({expression})'.replace(opnm, 'o0')
+    assert lxinfo['operands'] == dict(o0=operands[opnm])
+
+    # Check result data.
+    a = cat2.fetch(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    b = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    np.testing.assert_array_equal(a[:], b[:])
+
+
+def test_lazyexpr_getchunk(services, sub_urlbase, sub_jwt_cookie):
+    if not sub_jwt_cookie:
+        pytest.skip("authentication support needed")
+
+    opnm = 'ds'
+    oppt = f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
+    expression = f'{opnm} - 0'
+    operands = {opnm: oppt}
+    lxname = 'my_expr'
+
+    cat2.subscribe(TEST_CATERVA2_ROOT, sub_urlbase,
+                   auth_cookie=sub_jwt_cookie)
+    lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
+                           auth_cookie=sub_jwt_cookie)
+    assert lxpath == f'@scratch/{lxname}.b2nd'
+
+    # Get one chunk
+    chunk_ds = cat2.get_chunk(oppt, 0, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    chunk_expr = cat2.get_chunk(lxpath, 0, sub_urlbase, auth_cookie=sub_jwt_cookie)
+
+    # Check result data.
+    a = cat2.fetch(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    b = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    np.testing.assert_array_equal(a[:], b[:])
+    out = np.empty_like(a[:])
+    blosc2.decompress2(chunk_ds, out)
+    out_expr = np.empty_like(a[:])
+    blosc2.decompress2(chunk_expr, out_expr)
+    np.testing.assert_array_equal(out, out_expr)
+
+
+def test_expr_from_expr(services, sub_urlbase, sub_jwt_cookie):
+    if not sub_jwt_cookie:
+        pytest.skip("authentication support needed")
+
+    opnm = 'ds'
+    oppt = f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
     expression = f'{opnm} + 1'
     operands = {opnm: oppt}
     lxname = 'my_expr'
@@ -98,10 +159,10 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
 
     # Check result data.
     a = cat2.fetch(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    b = cat2.fetch(lxpath2, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    c = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    np.testing.assert_array_equal((a[:] + 1) * 2, b[:])
-    np.testing.assert_array_equal(a[:] + 1, c[:])
+    b = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    c = cat2.fetch(lxpath2, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    np.testing.assert_array_equal(a[:] + 1, b[:])
+    np.testing.assert_array_equal((a[:] + 1) * 2, c[:])
 
 
 def test_root(services, sub_urlbase, sub_user):

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -65,7 +65,7 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
 
     opnm = 'ds'
     oppt = f'{TEST_CATERVA2_ROOT}/ds-1d.b2nd'
-    expression = f'{opnm} + 0'
+    expression = f'{opnm} + 1'
     operands = {opnm: oppt}
     lxname = 'my_expr'
 
@@ -76,17 +76,32 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
                            auth_cookie=sub_jwt_cookie)
     assert lxpath == f'@scratch/{lxname}.b2nd'
 
+    expression2 = f'{opnm} * 2'
+    operands2 = {opnm: lxpath}
+    lxname = 'expr_from_expr'
+    lxpath2 = cat2.lazyexpr(lxname, expression2, operands2, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    assert lxpath2 == f'@scratch/{lxname}.b2nd'
+
     # Check result metadata.
     lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    assert lxinfo['shape'] == opinfo['shape']
-    assert lxinfo['dtype'] == opinfo['dtype']
+    lxinfo2 = cat2.get_info(lxpath2, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    assert lxinfo['shape'] == opinfo['shape'] == lxinfo2['shape']
+    assert lxinfo['dtype'] == opinfo['dtype'] == lxinfo2['dtype']
     assert lxinfo['expression'] == f'({expression})'.replace(opnm, 'o0')
+    assert lxinfo2['expression'] == '((o0 + 1) * 2)'
     assert lxinfo['operands'] == dict(o0=operands[opnm])
+    assert lxinfo2['operands'] == dict(o0=operands[opnm])
+
+    # Get one chunk
+    _ = cat2.get_chunk(lxpath2, 0, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    _ = cat2.get_chunk(lxpath, 0, sub_urlbase, auth_cookie=sub_jwt_cookie)
 
     # Check result data.
     a = cat2.fetch(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    b = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    np.testing.assert_array_equal(a[:], b[:])
+    b = cat2.fetch(lxpath2, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    c = cat2.fetch(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
+    np.testing.assert_array_equal((a[:] + 1) * 2, b[:])
+    np.testing.assert_array_equal(a[:] + 1, c[:])
 
 
 def test_root(services, sub_urlbase, sub_user):


### PR DESCRIPTION
This PR removes the 'NotImplementedError' from `get_chunk` when the dataset is a LazyExpr.