### PR TITLE
Support for uploading tar (tar.gz and .tgz are also in) and zipfiles.

### DIFF
--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -14,10 +14,8 @@ import logging
 import os
 import pathlib
 import re
-import shutil
 import string
 import tarfile
-import tempfile
 import typing
 import zipfile
 from collections.abc import Awaitable, Callable


### PR DESCRIPTION
It has occurred to me that supporting uploading and automatic extraction of tarballs or zipfiles would be a cool way to allow the creation of hierarchies in `@shared` (and `@scratch` too).  I'm still not sure how to deal with the redirection part (it is possible to point to a directory, or better use the first path in the tarball?).

Fixes #64.