### PR TITLE
remove() api

### DIFF
--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -15,5 +15,5 @@ __version__ = "2024.07.01"
 from .api import (bro_host_default, pub_host_default, sub_host_default,
                   sub_urlbase_default)
 from .api import (get_roots, subscribe, get_chunk, get_list, get_info, fetch,
-                  download, upload, lazyexpr)
+                  download, upload, remove, lazyexpr)
 from .api import Root, File, Dataset

--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -14,6 +14,6 @@ __version__ = "2024.07.01"
 
 from .api import (bro_host_default, pub_host_default, sub_host_default,
                   sub_urlbase_default)
-from .api import (get_roots, subscribe, get_chunk, get_list, get_info, fetch, download,
-                  lazyexpr)
+from .api import (get_roots, subscribe, get_chunk, get_list, get_info, fetch,
+                  download, upload, lazyexpr)
 from .api import Root, File, Dataset

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -277,9 +277,10 @@ def lazyexpr(name, expression, operands,
         The path of the created dataset.
     """
     urlbase, _ = _format_paths(urlbase)
+    # Convert possible Path objects in operands to strings so that they can be serialized
+    operands = {k: str(v) for k, v in operands.items()}
     expr = dict(name=name, expression=expression, operands=operands)
-    remotepath = api_utils.post(f'{urlbase}api/lazyexpr/', expr,
-                                auth_cookie=auth_cookie)
+    remotepath = api_utils.post(f'{urlbase}api/lazyexpr/', expr, auth_cookie=auth_cookie)
     return pathlib.Path(remotepath)
 
 

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -213,7 +213,7 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
 
     Returns
     -------
-    str
+    Path
         The path to the downloaded file.
     """
     urlbase, path = _format_paths(urlbase, path)
@@ -245,10 +245,8 @@ def upload(localpath, remotepath, urlbase=sub_urlbase_default, auth_cookie=None)
     Path
         The path of the uploaded file.
     """
-    # urlbase, path = _format_paths(urlbase, remote_dir)
-    remote_path = api_utils.upload_file(localpath, remotepath, urlbase, try_pack=api_utils.blosc2_is_here,
-                                        auth_cookie=auth_cookie)
-    return pathlib.Path(remote_path)
+    return api_utils.upload_file(localpath, remotepath, urlbase, try_pack=api_utils.blosc2_is_here,
+                                 auth_cookie=auth_cookie)
 
 
 def lazyexpr(name, expression, operands,
@@ -275,13 +273,14 @@ def lazyexpr(name, expression, operands,
 
     Returns
     -------
-    str
+    Path
         The path of the created dataset.
     """
     urlbase, _ = _format_paths(urlbase)
     expr = dict(name=name, expression=expression, operands=operands)
-    return api_utils.post(f'{urlbase}api/lazyexpr/', expr,
-                          auth_cookie=auth_cookie)
+    remotepath = api_utils.post(f'{urlbase}api/lazyexpr/', expr,
+                                auth_cookie=auth_cookie)
+    return pathlib.Path(remotepath)
 
 
 class Root:
@@ -518,7 +517,7 @@ class File:
 
         Returns
         -------
-        pathlib.PosixPath
+        Path
             The path to the downloaded file.
 
         Examples

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -221,6 +221,34 @@ def download(path, urlbase=sub_urlbase_default, auth_cookie=None):
     return api_utils.download_url(url, path, try_unpack=api_utils.blosc2_is_here,
                                   auth_cookie=auth_cookie)
 
+def upload(localpath, remotepath, urlbase=sub_urlbase_default, auth_cookie=None):
+    """
+    Upload a local dataset to a remote repository.
+
+    **Note:** If dataset in localpath is a regular file, and Blosc2 is installed,
+    it will be compressed prior to be uploaded.  Otherwise, it will be
+    uploaded as-is and compressed with Blosc2 on the server side.
+
+    Parameters
+    ----------
+    localpath : str
+        The path of the local dataset.
+    remotepath : str
+        The remote path to upload the dataset to.
+    urlbase : str
+        The base of URLs (slash-terminated) of the subscriber to query.
+    auth_cookie : str
+        An optional HTTP cookie for authorizing access.
+
+    Returns
+    -------
+    str
+        The path of the uploaded file.
+    """
+    # urlbase, path = _format_paths(urlbase, remote_dir)
+    return api_utils.upload_file(localpath, remotepath, urlbase, try_pack=api_utils.blosc2_is_here,
+                                 auth_cookie=auth_cookie)
+
 
 def lazyexpr(name, expression, operands,
              urlbase=sub_urlbase_default, auth_cookie=None):

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -231,9 +231,9 @@ def upload(localpath, remotepath, urlbase=sub_urlbase_default, auth_cookie=None)
 
     Parameters
     ----------
-    localpath : str
+    localpath : Path
         The path of the local dataset.
-    remotepath : str
+    remotepath : Path
         The remote path to upload the dataset to.
     urlbase : str
         The base of URLs (slash-terminated) of the subscriber to query.
@@ -338,6 +338,38 @@ class Root:
         else:
             return File(node, root=self.name, urlbase=self.urlbase,
                         auth_cookie=self.auth_cookie)
+
+    def upload(self, localpath, remotepath=None):
+        """
+        Upload a local dataset to this root.
+
+        Parameters
+        ----------
+        localpath : Path
+            The path of the local dataset.
+        remotepath : Path
+            The remote path to upload the dataset to.  If not provided, the
+            dataset will be uploaded to this root in top level.
+
+        Returns
+        -------
+        File
+            A :class:`File` or :class:`Dataset` instance.
+
+        Examples
+        --------
+        >>> root = cat2.Root('@scratch')
+        >>> root.upload('foo/mydataset.b2nd')
+        File: @scratch/foo/mydataset.md
+        """
+        if remotepath is None:
+            remotepath = self.name / localpath
+        r2 = upload(localpath, remotepath, urlbase=self.urlbase,
+                   auth_cookie=self.auth_cookie)
+        # list the contents of the root
+        self.node_list = api_utils.get(f'{self.urlbase}api/list/{self.name}',
+                                       auth_cookie=self.auth_cookie)
+        return self[str(localpath)]
 
 
 class File:

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -250,6 +250,34 @@ def upload(localpath, dataset, urlbase=sub_urlbase_default, auth_cookie=None):
                                  auth_cookie=auth_cookie)
 
 
+def remove(path, urlbase=sub_urlbase_default, auth_cookie=None):
+    """
+    Remove a dataset (or subroot path) from a remote repository.
+
+    Note that when a subroot is removed, only its contents are removed.
+    The subroot itself is not removed. This can be handy for future
+    uploads to the same subroot.  This is preliminary and may change in
+    future versions.
+
+    Parameters
+    ----------
+    path : Path
+        The path of the dataset or subroot.
+    urlbase : str
+        The base of URLs (slash-terminated) of the subscriber to query.
+    auth_cookie : str
+        An optional HTTP cookie for authorizing access.
+
+    Returns
+    -------
+    str
+        The removed path.
+    """
+    urlbase, path = _format_paths(urlbase, path)
+    return api_utils.post(f'{urlbase}api/remove/{path}',
+                          auth_cookie=auth_cookie)
+
+
 def lazyexpr(name, expression, operands,
              urlbase=sub_urlbase_default, auth_cookie=None):
     """
@@ -532,6 +560,24 @@ class File:
         urlpath = self.get_download_url()
         return api_utils.download_url(urlpath, str(self.path),
                                       auth_cookie=self.auth_cookie)
+
+    def remove(self):
+        """
+        Remove a file from a remote repository.
+
+        Returns
+        -------
+        str
+            The path of the removed file.
+
+        Examples
+        --------
+        >>> root = cat2.Root('@scratch')
+        >>> file = root['ds-1d.b2nd']
+        >>> file.remove()
+        '@scratch/ds-1d.b2nd'
+        """
+        return remove(self.path, urlbase=self.urlbase,  auth_cookie=self.auth_cookie)
 
 
 class Dataset(File):

--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -225,9 +225,10 @@ def upload(localpath, remotepath, urlbase=sub_urlbase_default, auth_cookie=None)
     """
     Upload a local dataset to a remote repository.
 
-    **Note:** If dataset in localpath is a regular file, and Blosc2 is installed,
-    it will be compressed prior to be uploaded.  Otherwise, it will be
-    uploaded as-is and compressed with Blosc2 on the server side.
+    **Note:** If `localpath` is a regular file (i.e. without a `.b2nd`,
+    `.b2frame` or `.b2` extension), it will be compressed with Blosc2 on the
+    server side (i.e. it will have the `.b2` extension appended internally,
+    although this won't be visible when using the web, API or CLI interfaces).
 
     Parameters
     ----------

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -141,19 +141,17 @@ def download_url(url, localpath, try_unpack=True, auth_cookie=None, server=None)
                 f.write(data)
         if is_b2 and try_unpack:
             localpath = b2_unpack(localpath)
-    return localpath
+    return pathlib.Path(localpath)
 
 
 def upload_file(localpath, remotepath, urlbase, try_pack=False, auth_cookie=None, server=None):
     client, url = get_client_and_url(server, f'{urlbase}api/upload/{remotepath}')
 
-    # TODO: Implement packing if needed
-
     headers = {'Cookie': auth_cookie} if auth_cookie else None
     with open(localpath, 'rb') as f:
         response = client.post(url, files={'file': f}, headers=headers)
         response.raise_for_status()
-    return response.json()
+    return pathlib.Path(response.json())
 
 
 #

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -126,6 +126,12 @@ _attachment_b2fname_rx = re.compile(r';\s*filename\*?\s*=\s*"([^"]+\.b2)"')
 def download_url(url, localpath, try_unpack=True, auth_cookie=None, server=None):
     client, url = get_client_and_url(server, url)
 
+    localpath = pathlib.Path(localpath)
+    localpath.parent.mkdir(parents=True, exist_ok=True)
+    if localpath.is_dir():
+        # Get the filename from the URL
+        localpath /= url.split('/')[-1]
+
     headers = {'Cookie': auth_cookie} if auth_cookie else None
     with client.stream("GET", url, headers=headers) as r:
         r.raise_for_status()
@@ -133,15 +139,14 @@ def download_url(url, localpath, try_unpack=True, auth_cookie=None, server=None)
         cdisp = r.headers.get('content-disposition', '')
         is_b2 = bool(_attachment_b2fname_rx.findall(cdisp))
         if is_b2:
-            localpath += '.b2'
-        localpath = pathlib.Path(localpath)
-        localpath.parent.mkdir(parents=True, exist_ok=True)
+            # Append '.b2' to the filename
+            localpath = localpath.with_suffix(localpath.suffix + '.b2')
         with open(localpath, "wb") as f:
             for data in r.iter_bytes():
                 f.write(data)
         if is_b2 and try_unpack:
             localpath = b2_unpack(localpath)
-    return pathlib.Path(localpath)
+    return localpath
 
 
 def upload_file(localpath, remotepath, urlbase, try_pack=False, auth_cookie=None, server=None):

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -144,6 +144,18 @@ def download_url(url, localpath, try_unpack=True, auth_cookie=None, server=None)
     return localpath
 
 
+def upload_file(localpath, remotepath, urlbase, try_pack=False, auth_cookie=None, server=None):
+    client, url = get_client_and_url(server, f'{urlbase}api/upload/{remotepath}')
+
+    # TODO: Implement packing if needed
+
+    headers = {'Cookie': auth_cookie} if auth_cookie else None
+    with open(localpath, 'rb') as f:
+        response = client.post(url, files={'file': f}, headers=headers)
+        response.raise_for_status()
+    return response.json()
+
+
 #
 # HTTP client helpers
 #

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -143,7 +143,7 @@ def cmd_show(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
-    path = cat2.download(args.dataset, args.urlbase, auth_cookie=auth_cookie)
+    path = cat2.download(args.dataset, args.localpath, args.urlbase, auth_cookie=auth_cookie)
     print(f'Dataset saved to {path}')
 
 
@@ -218,8 +218,8 @@ def main():
     help = 'Download a dataset and save it in the local system'
     subparser = subparsers.add_parser('download', help=help)
     subparser.add_argument('--json', action='store_true')
-    subparser.add_argument('dataset', type=str)
-    subparser.add_argument('output_dir', nargs='?', default='.', type=pathlib.Path)
+    subparser.add_argument('dataset', type=pathlib.Path)
+    subparser.add_argument('localpath', nargs='?', default=None, type=pathlib.Path)
     subparser.set_defaults(func=cmd_download)
 
     # upload

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -155,6 +155,13 @@ def cmd_upload(args, auth_cookie):
     print(f'Dataset stored in {path}')
 
 
+@handle_errors
+@with_auth_cookie
+def cmd_remove(args, auth_cookie):
+    removed = cat2.remove(args.dataset, args.urlbase, auth_cookie=auth_cookie)
+    print(f'Dataset (or subroot contents) removed: {removed}')
+
+
 def main():
     conf = utils.get_conf()
     parser = utils.get_parser()
@@ -221,6 +228,12 @@ def main():
     subparser.add_argument('localpath', type=pathlib.Path)
     subparser.add_argument('dataset', type=pathlib.Path)
     subparser.set_defaults(func=cmd_upload)
+
+    # remove
+    help = 'Remove a dataset from the subscriber'
+    subparser = subparsers.add_parser('remove', help=help)
+    subparser.add_argument('dataset', type=pathlib.Path)
+    subparser.set_defaults(func=cmd_remove)
 
     # Go
     args = utils.run_parser(parser)

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -150,7 +150,7 @@ def cmd_download(args, auth_cookie):
 @handle_errors
 @with_auth_cookie
 def cmd_upload(args, auth_cookie):
-    path = cat2.upload(args.localpath, args.remotepath,
+    path = cat2.upload(args.localpath, args.dataset,
                        args.urlbase, auth_cookie=auth_cookie)
     print(f'Dataset stored in {path}')
 
@@ -219,7 +219,7 @@ def main():
     help = 'Upload a local dataset to subscriber'
     subparser = subparsers.add_parser('upload', help=help)
     subparser.add_argument('localpath', type=pathlib.Path)
-    subparser.add_argument('remotepath', type=pathlib.Path)
+    subparser.add_argument('dataset', type=pathlib.Path)
     subparser.set_defaults(func=cmd_upload)
 
     # Go

--- a/caterva2/clients/cli.py
+++ b/caterva2/clients/cli.py
@@ -104,7 +104,6 @@ def cmd_url(args, auth_cookie):
     if args.json:
         print(json.dumps(data))
         return
-
     print(data)
 
 
@@ -118,7 +117,6 @@ def cmd_info(args, auth_cookie):
     if args.json:
         print(json.dumps(data))
         return
-
     rich.print(data)
 
 
@@ -146,8 +144,15 @@ def cmd_show(args, auth_cookie):
 @with_auth_cookie
 def cmd_download(args, auth_cookie):
     path = cat2.download(args.dataset, args.urlbase, auth_cookie=auth_cookie)
-
     print(f'Dataset saved to {path}')
+
+
+@handle_errors
+@with_auth_cookie
+def cmd_upload(args, auth_cookie):
+    path = cat2.upload(args.localpath, args.remotepath,
+                       args.urlbase, auth_cookie=auth_cookie)
+    print(f'Dataset stored in {path}')
 
 
 def main():
@@ -209,6 +214,13 @@ def main():
     subparser.add_argument('dataset', type=str)
     subparser.add_argument('output_dir', nargs='?', default='.', type=pathlib.Path)
     subparser.set_defaults(func=cmd_download)
+
+    # upload
+    help = 'Upload a local dataset to subscriber'
+    subparser = subparsers.add_parser('upload', help=help)
+    subparser.add_argument('localpath', type=pathlib.Path)
+    subparser.add_argument('remotepath', type=pathlib.Path)
+    subparser.set_defaults(func=cmd_upload)
 
     # Go
     args = utils.run_parser(parser)

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -533,7 +533,7 @@ def abspath_and_dataprep(path: pathlib.Path,
     """
     Get absolute path in local storage and data preparation operation.
 
-    After awaiting for the preparation operation to complete, data in the
+    After awaiting the preparation operation to complete, data in the
     dataset should be ready for reading, either that covered by the slice if
     given, or the whole data otherwise.
     """
@@ -799,12 +799,14 @@ async def upload_file(
         The path of the uploaded file.
     """
 
-    print(f"Uploading {file.filename} to {path}")
     if not user:
         raise fastapi.HTTPException(
             status_code=401,  # unauthorized
             detail="Uploading files requires enabling user authentication",
         )
+
+    # Read the file
+    data = await file.read()
 
     # Only allow uploading to the scratch or the shared space
     root = path.parts[0]
@@ -822,12 +824,19 @@ async def upload_file(
 
     # If path2 is a directory, append the filename
     if path2.is_dir():
-        path2 = path2 / file.filename
+        path2 /= file.filename
     path2.parent.mkdir(exist_ok=True, parents=True)
+
+    # If regular file, compress it
+    if path2.suffix not in {'.b2frame', '.b2nd'}:
+        schunk = blosc2.SChunk(data=data)
+        data = schunk.to_cframe()
+        # Append a new .b2 extension to the file, including the original extension
+        path2 = path2.with_suffix(path2.suffix + '.b2')
 
     # Write the file
     with open(path2, 'wb') as f:
-        f.write(await file.read())
+        f.write(data)
 
     # Return the urlpath
     return str(path)
@@ -1274,7 +1283,7 @@ async def htmx_upload(
     if filename.suffix not in {'.b2frame', '.b2nd'}:
         schunk = blosc2.SChunk(data=data)
         data = schunk.to_cframe()
-        filename = f'{filename}.b2frame'
+        filename = f'{filename}.b2'
 
     # Save file
     with open(path / filename, 'wb') as dst:

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -825,6 +825,7 @@ async def upload_file(
     # If path2 is a directory, append the filename
     if path2.is_dir():
         path2 /= file.filename
+        path /= file.filename
     path2.parent.mkdir(exist_ok=True, parents=True)
 
     # If regular file, compress it
@@ -840,7 +841,6 @@ async def upload_file(
 
     # Return the urlpath
     return str(path)
-    # return urlbase / path
 
 
 #

--- a/caterva2/tests/services.py
+++ b/caterva2/tests/services.py
@@ -161,7 +161,7 @@ class ManagedServices(Services):
             *([f"--http={check.host}"] if check else []),
             *args
         ]
-        popen = subprocess.Popen(popen_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        popen = subprocess.Popen(popen_args, stdout=sys.stdout, stderr=sys.stderr)
         command_line = ' '.join(str(x) for x in popen_args)
         self._procs[name] = popen
 
@@ -175,8 +175,6 @@ class ManagedServices(Services):
         for _ in range(int(start_timeout_secs / start_sleep_secs)):
             returncode = popen.poll()
             if returncode is not None:
-                logger.error(f'STDERR {popen.stderr.read()}')
-                logger.error(f'STDOUT {popen.stdout.read()}')
                 raise RuntimeError(
                     f"service {name} failed with returncode={returncode}, "
                     f"command = {command_line}"

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -362,7 +362,9 @@ def test_download_regular_file(services, examples_dir, sub_urlbase,
                                     ('dir1/ds-3d.b2nd', 'dir2/dir3/dir4/'),
                                     ])
 @pytest.mark.parametrize("root", [TEST_SCRATCH_ROOT, TEST_SHARED_ROOT])
-def test_upload(fnames, root, services, examples_dir, sub_urlbase, sub_user, sub_jwt_cookie, tmp_path):
+@pytest.mark.parametrize("remove", [False, True])
+def test_upload(fnames, remove, root, services, examples_dir,
+                sub_urlbase, sub_user, sub_jwt_cookie, tmp_path):
     if not sub_jwt_cookie:
         pytest.skip("authentication support needed")
 
@@ -385,6 +387,14 @@ def test_upload(fnames, root, services, examples_dir, sub_urlbase, sub_user, sub
                 assert remote_ds.name == remotepath
         else:
             assert remote_ds.name == str(path)
+        # Check removing the file
+        if remove:
+            remote_removed = pathlib.Path(remote_ds.remove())
+            assert remote_removed == remote_ds.path
+            # Check that the file has been removed
+            with pytest.raises(Exception) as e_info:
+                _ = remote_root[remote_removed]
+                assert str(e_info.value) == 'Not Found'
 
 
 @pytest.mark.parametrize("name", ['ds-1d.b2nd',

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -80,7 +80,7 @@ def test_lazyexpr(services, sub_urlbase, sub_jwt_cookie):
     opinfo = cat2.get_info(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
     lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
                            auth_cookie=sub_jwt_cookie)
-    assert lxpath == f'@scratch/{lxname}.b2nd'
+    assert lxpath == pathlib.Path(f'@scratch/{lxname}.b2nd')
 
     # Check result metadata.
     lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)
@@ -109,7 +109,7 @@ def test_lazyexpr_getchunk(services, sub_urlbase, sub_jwt_cookie):
                    auth_cookie=sub_jwt_cookie)
     lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
                            auth_cookie=sub_jwt_cookie)
-    assert lxpath == f'@scratch/{lxname}.b2nd'
+    assert lxpath == pathlib.Path(f'@scratch/{lxname}.b2nd')
 
     # Get one chunk
     chunk_ds = cat2.get_chunk(oppt, 0, sub_urlbase, auth_cookie=sub_jwt_cookie)
@@ -141,13 +141,13 @@ def test_expr_from_expr(services, sub_urlbase, sub_jwt_cookie):
     opinfo = cat2.get_info(oppt, sub_urlbase, auth_cookie=sub_jwt_cookie)
     lxpath = cat2.lazyexpr(lxname, expression, operands, sub_urlbase,
                            auth_cookie=sub_jwt_cookie)
-    assert lxpath == f'@scratch/{lxname}.b2nd'
+    assert lxpath == pathlib.Path(f'@scratch/{lxname}.b2nd')
 
     expression2 = f'{opnm} * 2'
     operands2 = {opnm: lxpath}
     lxname = 'expr_from_expr'
     lxpath2 = cat2.lazyexpr(lxname, expression2, operands2, sub_urlbase, auth_cookie=sub_jwt_cookie)
-    assert lxpath2 == f'@scratch/{lxname}.b2nd'
+    assert lxpath2 == pathlib.Path(f'@scratch/{lxname}.b2nd')
 
     # Check result metadata.
     lxinfo = cat2.get_info(lxpath, sub_urlbase, auth_cookie=sub_jwt_cookie)


### PR DESCRIPTION
This implements a `remove()` API.  Note that I used `remove` noun instead of `delete` (used in the `htmx` interface) because it seems to me that the former is more usual when removing files in filesystems (e.g. `os.remove()`, `os.rmdir()` or `shutil.rmtree()`). 