### PR TITLE
Add CParams property to proxy source

### DIFF
--- a/caterva2/models.py
+++ b/caterva2/models.py
@@ -14,23 +14,29 @@ import blosc2
 import pydantic
 
 
-class CParams(pydantic.BaseModel, extra='allow'):
+class CParams(pydantic.BaseModel, extra="allow"):
     codec: blosc2.Codec
+    codec_meta: int
+    clevel: int
     filters: list[blosc2.Filter]
     filters_meta: list[int]
     typesize: int
     blocksize: int
+    nthreads: int
+    splitmode: blosc2.SplitMode
+    tuner: blosc2.Tuner
+    use_dict: bool
 
 
-class SChunk(pydantic.BaseModel, extra='allow'):
+class SChunk(pydantic.BaseModel, extra="allow"):
     cbytes: int
     chunkshape: int
     chunksize: int
     contiguous: bool
     cparams: CParams
     cratio: float
-#   dparams
-#   meta
+    #   dparams
+    #   meta
     nbytes: int
     urlpath: str
     vlmeta: dict = {}

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -13,7 +13,6 @@ import itertools
 import logging
 import os
 import pathlib
-import random
 import re
 import shutil
 import string
@@ -90,6 +89,7 @@ class PubSourceDataset:
                     # This is a list, so we need to convert it to a string
                     dtype = eval(dtype)
                 self._dtype = np.dtype(dtype)
+                self._cparams = dict(metadata.schunk.cparams)
             else:
                 if suffix == ".b2frame":
                     metadata = models.SChunk(**metadata)
@@ -99,6 +99,9 @@ class PubSourceDataset:
                 self._typesize = metadata.cparams.typesize
                 self._chunksize = metadata.chunksize
                 self._nbytes = metadata.nbytes
+                self._cparams = dict(metadata.cparams)
+            del self._cparams["filters, meta"]
+            self._cparams = blosc2.CParams(**self._cparams)
             self.abspath = abspath
             if self.abspath is not None:
                 self.abspath.parent.mkdir(exist_ok=True, parents=True)
@@ -150,6 +153,10 @@ class PubNDDataset(blosc2.ProxyNDSource, PubSourceDataset):
     def dtype(self):
         return self._dtype
 
+    @property
+    def cparams(self):
+        return self._cparams
+
     def get_chunk(self, nchunk: int) -> bytes:
         return self._get_chunk(nchunk)
 
@@ -170,6 +177,10 @@ class PubSCDataset(blosc2.ProxySource, PubSourceDataset):
     @property
     def nbytes(self):
         return self._nbytes
+
+    @property
+    def cparams(self):
+        return self._cparams
 
     def get_chunk(self, nchunk: int) -> bytes:
         return self._get_chunk(nchunk)

--- a/caterva2/services/templates/includes/info_metadata.html
+++ b/caterva2/services/templates/includes/info_metadata.html
@@ -19,6 +19,13 @@
         {% set _ = meta.__setattr__('chunks', chunks) %}
 
         {% set cparams = meta.schunk.cparams %}
+        {% set _ = cparams.__delattr__('codec_meta') %}
+        {% set _ = cparams.__delattr__('clevel') %}
+        {% set _ = cparams.__delattr__('nthreads') %}
+        {% set _ = cparams.__delattr__('splitmode') %}
+        {% set _ = cparams.__delattr__('tuner') %}
+        {% set _ = cparams.__delattr__('use_dict') %}
+
         {% set schunk = meta.schunk %}
         {% for key, value in cparams %}
             {% if key not in ['filters', 'filters_meta'] %}


### PR DESCRIPTION
Right now, the cparams are not propagated properly to caterva2. This may fix the problem.