### PR TITLE
Added shape, dtype, blocks and chunks to Dataset class

### DIFF
--- a/caterva2/api.py
+++ b/caterva2/api.py
@@ -1260,6 +1260,22 @@ class Dataset(File):
         # TODO: add more info about dims, types, etc.
         return f"<Dataset: {self.path}>"
 
+    @property
+    def shape(self):
+        return self.meta.get('shape', None)
+
+    @property
+    def dtype(self):
+        return self.meta.get('dtype', None)
+
+    @property
+    def blocks(self):
+        return self.meta.get('blocks', None)
+
+    @property
+    def chunks(self):
+        return self.meta.get('chunks', None)
+
     def append(self, data):
         """
         Appends data to the dataset.

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -155,6 +155,16 @@ def test_file_public(sub_urlbase, fill_public):
         assert file.name == fname
         assert file.urlbase == sub_urlbase
 
+def test_dataset_info(sub_urlbase, fill_public):
+    fnames, mypublic = fill_public
+    for fname in fnames:
+        if type(mypublic[fname]) is cat2.Dataset: #files cannot be expected t
+            info=cat2.get_info('@public/' + fname, urlbase=sub_urlbase)
+            data=mypublic[fname]
+            assert data.shape == info['shape']
+            assert data.dtype == info['dtype']
+            assert data.blocks == info['blocks']
+            assert data.chunks == info['chunks']
 
 @pytest.mark.parametrize("dirpath", [None, "dir1", "dir2", "dir2/dir3/dir4"])
 @pytest.mark.parametrize("final_dir", [True, False])


### PR DESCRIPTION
For Dataset class (which inherits from File class), can now access certain meta-information directly. Test added which checks that the relevant attributes for Dataset instances are correct (but skips File instances).