### PR TITLE
Change exception handling in api_utils.fetch_data

### DIFF
--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -109,12 +109,13 @@ def fetch_data(path, urlbase, params, auth_cookie=None):
     # Try different deserialization methods
     try:
         data = blosc2.ndarray_from_cframe(data)
-        data = data[:] if data.ndim == 1 else data[()]
     except RuntimeError:
         data = blosc2.schunk_from_cframe(data)
-        data = data[:]
-    return data
-
+    if hasattr(data, 'ndim'): #if b2nd or b2frame
+        #catch 0d case where [:] fails
+        return data[()] if data.ndim == 0 else data[:]
+    else:
+        return data[:]
 
 def get_download_url(path, urlbase):
     return f"{urlbase}/api/fetch/{path}"


### PR DESCRIPTION
``fetch_data`` used to run
```
data = response.content
#Try different deserialization methods
try:
    data = blosc2.ndarray_from_cframe(data)
    data=data[:] if data.ndim==1 else data[()]
except RuntimeError:
    data = blosc2.schunk_from_cframe(data)
    data=data[:] 
```
which caused an uninformative error to be thrown in the except block if the second line in the try block failed (since data was no longer a bytes object). This has been changed to allow a more informative error to be thrown. In addition, changed indexing signature so that data[()] is used only on 0d arrays.