### PR TITLE
Add a new Dataset.slice() method

### DIFF
--- a/caterva2/__init__.py
+++ b/caterva2/__init__.py
@@ -9,7 +9,7 @@
 
 """Caterva2 - On demand access to remote Blosc2 data repositories"""
 
-from .client import BasicAuth, Client, Dataset, sub_urlbase_default
+from .client import BasicAuth, Client, Dataset, File, Root, sub_urlbase_default
 
 __version__ = "2025.02.20"
 """The version in use of the Caterva2 package."""
@@ -17,6 +17,8 @@ __version__ = "2025.02.20"
 __all__ = [
     "BasicAuth",
     "Client",
+    "Root",
+    "File",
     "Dataset",
     "sub_urlbase_default",
 ]

--- a/caterva2/api_utils.py
+++ b/caterva2/api_utils.py
@@ -103,7 +103,7 @@ def get_auth_cookie(urlbase, user_auth):
     return "=".join(list(resp.cookies.items())[0])
 
 
-def fetch_data(path, urlbase, params, auth_cookie=None):
+def fetch_data(path, urlbase, params, auth_cookie=None, as_blosc2=False):
     response = _xget(f"{urlbase}/api/fetch/{path}", params=params, auth_cookie=auth_cookie)
     data = response.content
     # Try different deserialization methods
@@ -111,11 +111,14 @@ def fetch_data(path, urlbase, params, auth_cookie=None):
         data = blosc2.ndarray_from_cframe(data)
     except RuntimeError:
         data = blosc2.schunk_from_cframe(data)
-    if hasattr(data, 'ndim'): #if b2nd or b2frame
-        #catch 0d case where [:] fails
+    if as_blosc2:
+        return data
+    if hasattr(data, "ndim"):  # if b2nd or b2frame
+        # catch 0d case where [:] fails
         return data[()] if data.ndim == 0 else data[:]
     else:
         return data[:]
+
 
 def get_download_url(path, urlbase):
     return f"{urlbase}/api/fetch/{path}"

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -291,7 +291,7 @@ def test_append(auth_client, fields, fill_auth, examples_dir):
     "slice_",
     [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None), slice(10, 20, 1)],
 )
-def test_index_dataset_frame(slice_, examples_dir, client):
+def test_dataset_getitem_fetch(slice_, examples_dir, client):
     myroot = client.get(TEST_CATERVA2_ROOT)
     ds = myroot["ds-hello.b2frame"]
     assert ds.name == "ds-hello.b2frame"
@@ -323,7 +323,7 @@ def test_dataset_step_diff_1(client):
     "slice_",
     [0, 1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None), slice(1, 5, 1)],
 )
-def test_index_dataset_1d(slice_, examples_dir, client):
+def test_getitem_dataset_1d(slice_, examples_dir, client):
     myroot = client.get(TEST_CATERVA2_ROOT)
     ds = myroot["ds-1d.b2nd"]
     assert ds.name == "ds-1d.b2nd"
@@ -348,7 +348,7 @@ def test_index_dataset_1d(slice_, examples_dir, client):
     ],
 )
 @pytest.mark.parametrize("name", ["dir1/ds-2d.b2nd", "dir2/ds-4d.b2nd"])
-def test_index_dataset_nd(slice_, name, examples_dir, client):
+def test_getitem_dataset_nd(slice_, name, examples_dir, client):
     myroot = client.get(TEST_CATERVA2_ROOT)
     ds = myroot[name]
     example = examples_dir / ds.name
@@ -359,9 +359,32 @@ def test_index_dataset_nd(slice_, name, examples_dir, client):
 
 @pytest.mark.parametrize(
     "slice_",
+    [
+        1,
+        slice(None, 1),
+        slice(0, 10),
+        slice(10, 20),
+        slice(None),
+        slice(1, 5, 1),
+        (slice(None, 10), slice(None, 20)),
+    ],
+)
+@pytest.mark.parametrize("name", ["dir1/ds-2d.b2nd", "dir2/ds-4d.b2nd"])
+def test_slice_dataset_nd(slice_, name, examples_dir, client):
+    myroot = client.get(TEST_CATERVA2_ROOT)
+    ds = myroot[name]
+    example = examples_dir / ds.name
+    a = blosc2.open(example)[:]
+    arr = ds.slice(slice_)
+    assert isinstance(arr, blosc2.NDArray)
+    np.testing.assert_array_equal(arr[()], a[slice_])
+
+
+@pytest.mark.parametrize(
+    "slice_",
     [1, slice(None, 1), slice(0, 10), slice(10, 20), slice(None), slice(1, 5, 1)],
 )
-def test_index_regular_file(slice_, examples_dir, client):
+def test_getitem_regular_file(slice_, examples_dir, client):
     myroot = client.get(TEST_CATERVA2_ROOT)
     ds = myroot["README.md"]
 

--- a/doc/reference/client_class.rst
+++ b/doc/reference/client_class.rst
@@ -5,7 +5,7 @@ Client class
 
 A client is a remote repository that can be subscribed to. It is the main entry point for using the Caterva2 API.
 
-.. currentmodule:: caterva2.client
+.. currentmodule:: caterva2
 
 
 Constructor

--- a/doc/reference/dataset_class.rst
+++ b/doc/reference/dataset_class.rst
@@ -5,14 +5,32 @@ Dataset class
 
 A dataset is a Blosc2-encoded file on a root repository (thus a :ref:`File <ref-API-File>`) representing either a flat string of bytes or an n-dimensional array.
 
-.. currentmodule:: caterva2
+.. currentmodule:: caterva2.client.Dataset
+
+
+Methods
+-------
+
+.. autosummary::
+    :toctree: autofiles
+    :nosignatures:
+
+    __init__
+    __getitem__
+    fetch
+    slice
+    append
+    get_download_url
+    download
+    vlmeta
+
+Attributes
+----------
+
 .. autosummary::
     :toctree: autofiles
 
-    Dataset.__init__
-    Dataset.__getitem__
-    Dataset.append
-    Dataset.get_download_url
-    Dataset.fetch
-    Dataset.download
-    Dataset.vlmeta
+    shape
+    chunks
+    blocks
+    dtype

--- a/doc/reference/file_class.rst
+++ b/doc/reference/file_class.rst
@@ -5,7 +5,7 @@ File class
 
 A file is either a Blosc2 dataset or a regular file on a root repository.
 
-.. currentmodule:: caterva2.client
+.. currentmodule:: caterva2
 .. autosummary::
     :toctree: autofiles
 

--- a/doc/reference/root_class.rst
+++ b/doc/reference/root_class.rst
@@ -5,7 +5,7 @@ Root class
 
 A root is a remote repository that can be subscribed to.
 
-.. currentmodule:: caterva2.client
+.. currentmodule:: caterva2
 .. autosummary::
     :toctree: autofiles
 

--- a/examples/get-slice.py
+++ b/examples/get-slice.py
@@ -1,0 +1,40 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2025 ironArray SLU <contact@ironarray.io>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+import math
+from time import time
+
+import caterva2 as cat2
+
+# Choose the dataset to open
+# dsname = 'examples/sa-1M.b2nd'
+dsname = "examples/lung-jpeg2000_10x.b2nd"
+# dsname = 'examples/uncompressed_lung-jpeg2000_10x.b2nd'
+
+# Open a client to the Cat2Cloud server
+client = cat2.Client("https://cat2.cloud/demo")
+info = client.get_info(f"@public/{dsname}")
+print(f"Client info: {info.keys()}")
+typesize = info["schunk"]["cparams"]["typesize"]
+# Open the public root
+root = client.get("@public")
+# Open the remote array
+t0 = time()
+remote_array = root[dsname]
+size = math.prod(remote_array.shape) * typesize
+print(f"Time for opening data (HTTP): {time() - t0:.3f}s - file size: {size / 2**10:.2f} KB")
+
+# Download a slice of the remote array as a numpy array
+t0 = time()
+na = remote_array[5:9]
+print(f"Time for reading data (getitem): {time() - t0:.3f}s - data size: {na.nbytes / 2**10:.2f} KB")
+
+# Download a slice of the remote array
+t0 = time()
+a = remote_array.slice(slice(5, 9))
+print(f"Time for reading data (slice): {time() - t0:.3f}s - data size: {a.schunk.nbytes / 2**10:.2f} KB")


### PR DESCRIPTION
This allows to receive a native `NDArray` or `SChunk`  right in the client, without any conversion.