### PR TITLE
Improved exception handling for Dataset attributes

### DIFF
--- a/caterva2/client.py
+++ b/caterva2/client.py
@@ -569,19 +569,31 @@ class Dataset(File):
 
     @property
     def dtype(self):
-        return self.meta.get("dtype", None)
+        try:
+            return self.meta["dtype"]
+        except KeyError:
+            raise AttributeError("'Dataset' object has no attribute 'dtype'.")
 
     @property
     def shape(self):
-        return tuple(self.meta.get("shape", None))
+        try:
+            return tuple(self.meta["shape"])
+        except KeyError:
+            raise AttributeError("'Dataset' object has no attribute 'shape'.")
 
     @property
     def chunks(self):
-        return tuple(self.meta.get("chunks", None))
+        try:
+            return tuple(self.meta["chunks"])
+        except KeyError:
+            raise AttributeError("'Dataset' object has no attribute 'chunks'.")
 
     @property
     def blocks(self):
-        return tuple(self.meta.get("blocks", None))
+        try:
+            return tuple(self.meta["blocks"])
+        except KeyError:
+            raise AttributeError("'Dataset' object has no attribute 'blocks'.")
 
     def append(self, data):
         """

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -177,7 +177,7 @@ def test_file_public(client, fill_public):
 def test_dataset_info(client, fill_public):
     fnames, mypublic = fill_public
     for fname in fnames:
-        if type(mypublic[fname]) is cat2.Dataset:  # files cannot be expected t
+        if type(mypublic[fname]) is cat2.Dataset:  # Files cannot be expected to have attributes
             info = client.get_info("@public/" + fname)
             data = mypublic[fname]
             assert data.dtype == info["dtype"]


### PR DESCRIPTION
Previously reurned None if Dataset.meta did not have attribute. This causes an error to be thrown for shpare, blocks and chunks since `tuple(None)` fails. Now throws more informative AttributeError.