### PR TITLE
Simplify API: remove File.fetch() as it duplicates File.__getitem__()

### DIFF
--- a/caterva2/client.py
+++ b/caterva2/client.py
@@ -378,7 +378,7 @@ class File:
         """
         # Convert slices to strings
         slice_ = api_utils.slice_to_string(key)
-        # Fetch and return the data as a NumPy array
+        # Fetch and return the data as a Blosc2 object / NumPy array
         return api_utils.fetch_data(
             self.path, self.urlbase, {"slice_": slice_}, auth_cookie=self.cookie, as_blosc2=as_blosc2
         )

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -301,10 +301,8 @@ def test_dataset_getitem_fetch(slice_, examples_dir, client):
     a = blosc2.open(example)[:]
     if isinstance(slice_, int):
         assert ord(ds[slice_]) == a[slice_]  # TODO: why do we need ord() here?
-        assert ord(ds.fetch(slice_)) == a[slice_]
     else:
         assert ds[slice_] == a[slice_]
-        assert ds.fetch(slice_) == a[slice_]
 
 
 def test_dataset_step_diff_1(client):
@@ -332,7 +330,6 @@ def test_getitem_dataset_1d(slice_, examples_dir, client):
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
     np.testing.assert_array_equal(ds[slice_], a[slice_])
-    np.testing.assert_array_equal(ds.fetch(slice_), a[slice_])
 
 
 @pytest.mark.parametrize(
@@ -354,7 +351,6 @@ def test_getitem_dataset_nd(slice_, name, examples_dir, client):
     example = examples_dir / ds.name
     a = blosc2.open(example)[:]
     np.testing.assert_array_equal(ds[slice_], a[slice_])
-    np.testing.assert_array_equal(ds.fetch(slice_), a[slice_])
 
 
 @pytest.mark.parametrize(
@@ -393,10 +389,8 @@ def test_getitem_regular_file(slice_, examples_dir, client):
     a = open(example).read().encode()
     if isinstance(slice_, int):
         assert ord(ds[slice_]) == a[slice_]  # TODO: why do we need ord() here?
-        assert ord(ds.fetch(slice_)) == a[slice_]
     else:
         assert ds[slice_] == a[slice_]
-        assert ds.fetch(slice_) == a[slice_]
 
 
 @pytest.mark.parametrize(

--- a/doc/reference/dataset_class.rst
+++ b/doc/reference/dataset_class.rst
@@ -17,7 +17,6 @@ Methods
 
     __init__
     __getitem__
-    fetch
     slice
     append
     get_download_url

--- a/doc/reference/file_class.rst
+++ b/doc/reference/file_class.rst
@@ -12,7 +12,6 @@ A file is either a Blosc2 dataset or a regular file on a root repository.
     File.__init__
     File.__getitem__
     File.get_download_url
-    File.fetch
     File.download
     File.remove
     File.move


### PR DESCRIPTION
The title says it all.