### PR TITLE
Make operands arg optional for lazyexprs

### DIFF
--- a/caterva2/client.py
+++ b/caterva2/client.py
@@ -1130,7 +1130,7 @@ class Client:
         )
         return pathlib.PurePosixPath(result)
 
-    def lazyexpr(self, name, expression, operands=None):
+    def lazyexpr(self, name, expression, operands=None, compute=False):
         """
         Creates a lazy expression dataset in personal space.
 
@@ -1145,6 +1145,10 @@ class Client:
             Expression to be evaluated, which must yield a lazy expression.
         operands : dict
             Mapping of variables in the expression to their corresponding dataset paths.
+        compute : bool, optional
+            If false, generate lazyexpr and do not compute anything.
+            If true, compute lazy expression on creation and save (full) result.
+            Default false.
 
         Returns
         -------
@@ -1173,7 +1177,7 @@ class Client:
                 "User has not provided operands for the LazyExpression. Proceeding with empty operands arg"
             )
             operands = {}
-        expr = {"name": name, "expression": expression, "operands": operands}
+        expr = {"name": name, "expression": expression, "operands": operands, "lazy": not compute}
         dataset = api_utils.post(f"{self.urlbase}/api/lazyexpr/", expr, auth_cookie=self.cookie)
         return pathlib.PurePosixPath(dataset)
 

--- a/caterva2/client.py
+++ b/caterva2/client.py
@@ -1,5 +1,6 @@
 import functools
 import io
+import logging
 import pathlib
 import sys
 from collections.abc import Sequence
@@ -1129,7 +1130,7 @@ class Client:
         )
         return pathlib.PurePosixPath(result)
 
-    def lazyexpr(self, name, expression, operands):
+    def lazyexpr(self, name, expression, operands=None):
         """
         Creates a lazy expression dataset in personal space.
 
@@ -1165,7 +1166,13 @@ class Client:
         """
         urlbase, _ = _format_paths(self.urlbase)
         # Convert possible Path objects in operands to strings so that they can be serialized
-        operands = {k: str(v) for k, v in operands.items()}
+        if operands is not None:
+            operands = {k: str(v) for k, v in operands.items()}
+        else:
+            logging.warning(
+                "User has not provided operands for the LazyExpression. Proceeding with empty operands arg"
+            )
+            operands = {}
         expr = {"name": name, "expression": expression, "operands": operands}
         dataset = api_utils.post(f"{self.urlbase}/api/lazyexpr/", expr, auth_cookie=self.cookie)
         return pathlib.PurePosixPath(dataset)

--- a/caterva2/models.py
+++ b/caterva2/models.py
@@ -65,6 +65,7 @@ class NewLazyExpr(pydantic.BaseModel):
     name: str
     expression: str
     operands: dict[str, str]
+    lazy: bool
 
 
 class MoveCopyPayload(pydantic.BaseModel):

--- a/caterva2/services/sub.py
+++ b/caterva2/services/sub.py
@@ -969,7 +969,7 @@ async def lazyexpr(
         return fastapi.HTTPException(status_code=400, detail=msg)  # bad request
 
     try:
-        result_path = make_expr(expr.name, expr.expression, expr.operands, user)
+        result_path = make_expr(expr.name, expr.expression, expr.operands, user, expr.lazy)
     except (SyntaxError, ValueError, TypeError) as exc:
         raise error(f"Invalid name or expression: {exc}") from exc
     except KeyError as ke:

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -655,7 +655,7 @@ def test_lazyexpr(auth_client):
     lxinfo = auth_client.get_info(lxpath)
     assert lxinfo["shape"] == opinfo["shape"]
     assert lxinfo["dtype"] == opinfo["dtype"]
-    assert lxinfo["expression"] == f"{expression}"
+    assert lxinfo["expression"] == f"({expression})"
     assert lxinfo["operands"] == operands
 
     # Check result data.
@@ -720,8 +720,8 @@ def test_expr_from_expr(auth_client):
     lxinfo2 = auth_client.get_info(lxpath2)
     assert lxinfo["shape"] == opinfo["shape"] == lxinfo2["shape"]
     assert lxinfo["dtype"] == opinfo["dtype"] == lxinfo2["dtype"]
-    assert lxinfo["expression"] == f"{expression}"
-    assert lxinfo2["expression"] == f"{expression2}"
+    assert lxinfo["expression"] == f"({expression})"
+    assert lxinfo2["expression"] == f"({expression2})"
     assert lxinfo["operands"] == operands
     assert lxinfo2["operands"] == operands2
 

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -747,7 +747,7 @@ def test_expr_no_operand(auth_client):
     a = blosc2.linspace(0, 10)
     np.testing.assert_array_equal(a[:], c[:])
 
-    # Check error when operand should be present but isnt
+    # Check error when operand should be present but isn't
     opnm = "ds"
     oppt = f"{TEST_CATERVA2_ROOT}/ds-1d.b2nd"
     expression = "ds + linspace(0, 10)"
@@ -758,9 +758,29 @@ def test_expr_no_operand(auth_client):
         lxpath = auth_client.lazyexpr(lxname, expression)
 
 
+def test_expr_force_compute(auth_client):
+    if not auth_client:
+        pytest.skip("authentication support needed")
+
+    expression = "linspace(0, 10)"
+    lxname = "my_expr"
+
+    auth_client.subscribe(TEST_CATERVA2_ROOT)
+
+    # Uncomputed lazyexpr is a blosc2 lazyexpr
+    lxpath = auth_client.lazyexpr(lxname, expression, compute=False)
+    assert lxpath == pathlib.Path(f"@personal/{lxname}.b2nd")
+    c = auth_client.get(lxpath)
+    assert c.meta["expression"] == expression
+
+    # Computed lazyexpr is a blosc2 array
+    lxpath = auth_client.lazyexpr(lxname, expression, compute=True)
+    assert lxpath == pathlib.Path(f"@personal/{lxname}.b2nd")
+    c = auth_client.get(lxpath)
+    assert c.meta.get("expression", None) is None
+
+
 # User management
-
-
 def test_adduser(auth_client):
     if not auth_client:
         pytest.skip("authentication support needed")

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -733,6 +733,31 @@ def test_expr_from_expr(auth_client):
     np.testing.assert_array_equal((a[:] + 1) * 2, c[:])
 
 
+def test_expr_no_operand(auth_client):
+    if not auth_client:
+        pytest.skip("authentication support needed")
+
+    expression = "linspace(0, 10)"
+    lxname = "my_expr"
+
+    auth_client.subscribe(TEST_CATERVA2_ROOT)
+    lxpath = auth_client.lazyexpr(lxname, expression)
+    assert lxpath == pathlib.Path(f"@personal/{lxname}.b2nd")
+    c = auth_client.get(lxpath)
+    a = blosc2.linspace(0, 10)
+    np.testing.assert_array_equal(a[:], c[:])
+
+    # Check error when operand should be present but isnt
+    opnm = "ds"
+    oppt = f"{TEST_CATERVA2_ROOT}/ds-1d.b2nd"
+    expression = "ds + linspace(0, 10)"
+    lxname = "my_expr"
+
+    auth_client.subscribe(TEST_CATERVA2_ROOT)
+    with pytest.raises(Exception) as e_info:
+        lxpath = auth_client.lazyexpr(lxname, expression)
+
+
 # User management
 
 


### PR DESCRIPTION
Allows one to send lazyexprs such as ``linspace(0, 10)`` to the server without specifying a dummy argument. Fixes #170. 

In order for this to be useful, added the ability to force execution of the sent lazyexpr server-side.