### PR TITLE
Make lazyexpr metadata more readable

### DIFF
--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -145,9 +145,19 @@ def read_metadata(obj, cache=None, personal=None, shared=None, public=None):
         return get_model_from_obj(schunk, models.SChunk, cparams=cparams, mtime=mtime)
     elif isinstance(obj, blosc2.LazyExpr):
         # overwrite operands and expression with _tosave versions for metadata display
-        operands = operands_as_paths(obj.operands_tosave, cache, personal, shared, public)
+        operands = operands_as_paths(
+            obj.operands_tosave if hasattr(obj, "operands_tosave") else obj.operands,
+            cache,
+            personal,
+            shared,
+            public,
+        )
         return get_model_from_obj(
-            obj, models.LazyArray, operands=operands, mtime=mtime, expression=obj.expression_tosave
+            obj,
+            models.LazyArray,
+            operands=operands,
+            mtime=mtime,
+            expression=obj.expression_tosave if hasattr(obj, "expression_tosave") else obj.expression,
         )
     else:
         raise TypeError(f"unexpected {type(obj)}")

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -144,8 +144,11 @@ def read_metadata(obj, cache=None, personal=None, shared=None, public=None):
         cparams = reformat_cparams(cparams)
         return get_model_from_obj(schunk, models.SChunk, cparams=cparams, mtime=mtime)
     elif isinstance(obj, blosc2.LazyExpr):
-        operands = operands_as_paths(obj.operands, cache, personal, shared, public)
-        return get_model_from_obj(obj, models.LazyArray, operands=operands, mtime=mtime)
+        # overwrite operands and expression with _tosave versions for metadata display
+        operands = operands_as_paths(obj.operands_tosave, cache, personal, shared, public)
+        return get_model_from_obj(
+            obj, models.LazyArray, operands=operands, mtime=mtime, expression=obj.expression_tosave
+        )
     else:
         raise TypeError(f"unexpected {type(obj)}")
 

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -658,11 +658,6 @@ def test_lazyexpr(auth_client):
     assert lxinfo["expression"] == expression
     assert lxinfo["operands"] == operands
 
-    # tempexp = re.sub(
-    #     r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
-    # )  # ds -> o0 automatically
-    # assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
-
     # Check result data.
     a = auth_client.fetch(oppt)
     b = auth_client.fetch(lxpath)
@@ -728,17 +723,6 @@ def test_expr_from_expr(auth_client):
     assert lxinfo["operands"] == operands
     assert lxinfo["expression"] == expression
 
-    # tempexp = re.sub(
-    #     r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
-    # )  # ds -> o0 automatically
-    # assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
-
-    # tempexp = lxinfo2["expression"]
-    # for i, (_op, f) in enumerate(lxinfo2["operands"].items()):
-    #     tempexp = re.sub(rf"(?<=\s)o{i}|(?<=\()o{i}", f, tempexp)
-    # step1 = f"({re.sub(r'ds', f'({expression})', expression2)})"
-    # step2 = f"{re.sub(r'ds', operands['ds'], step1)}"
-    # assert tempexp == step2
     assert lxinfo2["operands"] == operands2
     assert lxinfo2["expression"] == expression2
 

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -8,7 +8,6 @@
 ###############################################################################
 import contextlib
 import pathlib
-import re
 
 import blosc2
 import httpx
@@ -656,10 +655,13 @@ def test_lazyexpr(auth_client):
     lxinfo = auth_client.get_info(lxpath)
     assert lxinfo["shape"] == opinfo["shape"]
     assert lxinfo["dtype"] == opinfo["dtype"]
-    tempexp = re.sub(
-        r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
-    )  # ds -> o0 automatically
-    assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
+    assert lxinfo["expression"] == expression
+    assert lxinfo["operands"] == operands
+
+    # tempexp = re.sub(
+    #     r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
+    # )  # ds -> o0 automatically
+    # assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
 
     # Check result data.
     a = auth_client.fetch(oppt)
@@ -723,18 +725,22 @@ def test_expr_from_expr(auth_client):
     lxinfo2 = auth_client.get_info(lxpath2)
     assert lxinfo["shape"] == opinfo["shape"] == lxinfo2["shape"]
     assert lxinfo["dtype"] == opinfo["dtype"] == lxinfo2["dtype"]
+    assert lxinfo["operands"] == operands
+    assert lxinfo["expression"] == expression
 
-    tempexp = re.sub(
-        r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
-    )  # ds -> o0 automatically
-    assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
+    # tempexp = re.sub(
+    #     r"(?<=\s)o0|(?<=\()o0", lxinfo["operands"]["o0"], lxinfo["expression"]
+    # )  # ds -> o0 automatically
+    # assert tempexp == f"({re.sub(r'ds', operands['ds'], expression)})"
 
-    tempexp = lxinfo2["expression"]
-    for i, (_op, f) in enumerate(lxinfo2["operands"].items()):
-        tempexp = re.sub(rf"(?<=\s)o{i}|(?<=\()o{i}", f, tempexp)
-    step1 = f"({re.sub(r'ds', f'({expression})', expression2)})"
-    step2 = f"{re.sub(r'ds', operands['ds'], step1)}"
-    assert tempexp == step2
+    # tempexp = lxinfo2["expression"]
+    # for i, (_op, f) in enumerate(lxinfo2["operands"].items()):
+    #     tempexp = re.sub(rf"(?<=\s)o{i}|(?<=\()o{i}", f, tempexp)
+    # step1 = f"({re.sub(r'ds', f'({expression})', expression2)})"
+    # step2 = f"{re.sub(r'ds', operands['ds'], step1)}"
+    # assert tempexp == step2
+    assert lxinfo2["operands"] == operands2
+    assert lxinfo2["expression"] == expression2
 
     # Check result data.
     a = auth_client.fetch(oppt)


### PR DESCRIPTION
Rather than internal representation of lazyexpr (used for calculation), display the original string expression and operands, which will be more familiar to the user.