### PR TITLE
Adding explicit Timeout error for informing users

### DIFF
--- a/caterva2/client.py
+++ b/caterva2/client.py
@@ -934,17 +934,32 @@ class Client:
         urlbase, path = _format_paths(self.urlbase, path)
         if field:  # blosc2 doesn't support indexing of multiple fields
             return api_utils.fetch_data(
-                path, urlbase, {"field": field}, auth_cookie=self.cookie, as_blosc2=as_blosc2
+                path,
+                urlbase,
+                {"field": field},
+                auth_cookie=self.cookie,
+                as_blosc2=as_blosc2,
+                timeout=self.timeout,
             )
         if isinstance(key, str):  # A filter has been passed
             return api_utils.fetch_data(
-                path, urlbase, {"filter": key}, auth_cookie=self.cookie, as_blosc2=as_blosc2
+                path,
+                urlbase,
+                {"filter": key},
+                auth_cookie=self.cookie,
+                as_blosc2=as_blosc2,
+                timeout=self.timeout,
             )
         else:  # Convert slices to strings
             slice_ = api_utils.slice_to_string(key)
             # Fetch and return the data as a Blosc2 object / NumPy array
             return api_utils.fetch_data(
-                path, urlbase, {"slice_": slice_}, auth_cookie=self.cookie, as_blosc2=as_blosc2
+                path,
+                urlbase,
+                {"slice_": slice_},
+                auth_cookie=self.cookie,
+                as_blosc2=as_blosc2,
+                timeout=self.timeout,
             )
 
     def get_chunk(self, path, nchunk):

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -1029,3 +1029,4 @@ def test_client_timeout(auth_client):
     with pytest.raises(Exception) as e_info:
         _ = auth_client.lazyexpr("expr", "linspace(0, 100, 1000_0000)", compute=True)
     assert "Timeout" in str(e_info)
+    auth_client.timeout = 5  # Reset timeout to default value

--- a/caterva2/tests/test_api.py
+++ b/caterva2/tests/test_api.py
@@ -1015,3 +1015,17 @@ def test_listusers_unauthorized(client, auth_client):
     with pytest.raises(Exception) as e_info:
         _ = client.listusers()
     assert "Not Found" in str(e_info)
+
+
+def test_client_timeout(auth_client):
+    if not auth_client:
+        pytest.skip("authentication support needed")
+
+    auth_client.subscribe(TEST_CATERVA2_ROOT)
+    lxpath = auth_client.lazyexpr("expr", "linspace(0, 100, 1000_0000)", compute=True)
+    assert lxpath == pathlib.Path("@personal/expr.b2nd")
+    auth_client.timeout = 0.0001
+    # Try again
+    with pytest.raises(Exception) as e_info:
+        _ = auth_client.lazyexpr("expr", "linspace(0, 100, 1000_0000)", compute=True)
+    assert "Timeout" in str(e_info)

--- a/examples/Video4-LazyExprs_Using_Notebooks.ipynb
+++ b/examples/Video4-LazyExprs_Using_Notebooks.ipynb
@@ -341,9 +341,7 @@
    "cell_type": "markdown",
    "id": "2f180dac27c7cf91",
    "metadata": {},
-   "source": [
-    "To execute this notebook in a browser running on WSL, run ``jupyter notebook --port=8889 --no-browser`` in the WSL terminal."
-   ]
+   "source": "To execute this notebook in a browser running on WSL, run ``jupyter notebook --port=8889 --no-browser`` in the WSL terminal."
   }
  ],
  "metadata": {


### PR DESCRIPTION
Improve coverage of Timeout errors for fetch_data and add explicit error message at level of Caterva2 to guide users to increase timeout limit for Client instance.