### PR TITLE
Adding concat command to caterva2

### DIFF
--- a/caterva2/models.py
+++ b/caterva2/models.py
@@ -86,6 +86,12 @@ class MoveCopyPayload(pydantic.BaseModel):
     dst: str
 
 
+class ConcatPayload(pydantic.BaseModel):
+    axis: int
+    srcs: list[str]
+    dst: str
+
+
 class AddUserPayload(pydantic.BaseModel):
     username: str
     password: str | None


### PR DESCRIPTION
Enable a concat prompt command (and accessible programmatically via File/Client instance). Syntax for prompt is ``concat <axis> <src1> ... <srcN> > <dst>". Sources must be paths or aliases but destination will be massaged to a .b2nd file stored in personal if not specified.