### PR TITLE
Say which responses serve byte ranges, and serve container leaves from theirs

### DIFF
--- a/caterva2/services/server.py
+++ b/caterva2/services/server.py
@@ -585,6 +585,7 @@ async def fetch_data(
     user: db.User = Depends(optional_user),
     filter: str | None = None,
     field: str | None = None,
+    range_header: str | None = fastapi.Header(None, alias="Range"),
 ):
     """
     Fetch a dataset.
@@ -610,6 +611,12 @@ async def fetch_data(
         to be downloaded (instead of some slice which does not cover it fully),
         its stored image is served containing all data and metadata (including
         variable length fields).
+
+    The `FileResponse` case, and only that one, serves byte ranges: a client
+    can read the header, the chunk offsets and single blocks of a stored frame
+    instead of transferring it whole (blosc2's Proxy over a C2Array does).
+    Everything else is built as it is sent and answers a `Range` header with a
+    416, rather than quietly returning the whole body with a 200.
     """
 
     slice_ = parse_slice(slice_)
@@ -631,12 +638,20 @@ async def fetch_data(
         if isinstance(data, bytes):
             # Already a serialized cframe (e.g. a peer CTable row range):
             # stream it as-is, no numpy wrap.
+            srv_utils.refuse_range(range_header, path)
             return responses.StreamingResponse(
-                srv_utils.iterchunk(data), media_type="application/octet-stream"
+                srv_utils.iterchunk(data),
+                media_type="application/octet-stream",
+                headers=srv_utils.NO_RANGES,
             )
+        # A peer dataset is fetched from its owner and re-serialized here, so
+        # there is no file to seek into
+        srv_utils.refuse_range(range_header, path)
         cframe = await asyncio.to_thread(lambda: blosc2.asarray(np.ascontiguousarray(data)).to_cframe())
         downloader = srv_utils.iterchunk(cframe)
-        return responses.StreamingResponse(downloader, media_type="application/octet-stream")
+        return responses.StreamingResponse(
+            downloader, media_type="application/octet-stream", headers=srv_utils.NO_RANGES
+        )
 
     abspath, inner_key = split_and_resolve(path, user)
 
@@ -710,8 +725,14 @@ async def fetch_data(
         and inner_key is None  # abspath is the container, not this leaf: never stream it whole
     ):
         # Send the data in the file straight to the client,
-        # avoiding slicing and re-compression.
+        # avoiding slicing and re-compression.  This is also the one branch that
+        # serves byte ranges: FileResponse seeks into the file and sends only
+        # what was asked for, which is what block-granular clients read.
         return FileResponse(abspath, filename=abspath.name, media_type="application/octet-stream")
+
+    # Everything below builds its answer, so a range cannot be honoured: say so
+    # here, before computing a body that is not going to be sent
+    srv_utils.refuse_range(range_header, path)
 
     if isinstance(array, blosc2.CTable):
         row_start, row_stop = srv_utils.ctable_row_range(slice_, array.nrows)
@@ -743,7 +764,9 @@ async def fetch_data(
         data = schunk.to_cframe()
 
     downloader = srv_utils.iterchunk(data)
-    return responses.StreamingResponse(downloader, media_type="application/octet-stream")
+    return responses.StreamingResponse(
+        downloader, media_type="application/octet-stream", headers=srv_utils.NO_RANGES
+    )
 
 
 @app.get("/api/download/{path:path}")
@@ -751,7 +774,12 @@ async def download_data(
     path: pathlib.Path,
     user: db.User = Depends(optional_user),
     accept_encoding: str | None = fastapi.Header(None),
+    range_header: str | None = fastapi.Header(None, alias="Range"),
 ):
+    # This one always streams, decompressing on the way out more often than not,
+    # so it never serves ranges; api/fetch on a stored dataset is what does.  The
+    # refusal comes after the path is resolved, so a path that does not exist is
+    # still a 404 rather than a 416 about a file nobody has.
     provider = providers.provider_for(path.parts[0])
     if provider is not None:
         try:
@@ -760,19 +788,22 @@ async def download_data(
             )
         except providers.ProviderError as exc:
             raise fastapi.HTTPException(status_code=exc.status_code, detail=exc.detail or None) from exc
+        srv_utils.refuse_range(range_header, path)
         headers.setdefault("Content-Disposition", f'attachment; filename="{path.name}"')
+        headers.update(srv_utils.NO_RANGES)
         return responses.StreamingResponse(body, media_type=media_type, headers=headers)
 
     decompress = accept_encoding != "blosc2"
     # Read before creating the response: a bad path must 404 up front, not
     # abort the stream after the 200 headers already went out.
     content = await get_file_content(path, user, decompress=decompress)
+    srv_utils.refuse_range(range_header, path)
 
     async def downloader():
         yield content
 
     mimetype = guess_type(path)
-    headers = {"Content-Disposition": f'attachment; filename="{path.name}"'}
+    headers = {"Content-Disposition": f'attachment; filename="{path.name}"', **srv_utils.NO_RANGES}
     if accept_encoding == "blosc2":
         abspath = get_abspath(path, user)
         suffix = abspath.suffix

--- a/caterva2/services/server.py
+++ b/caterva2/services/server.py
@@ -500,6 +500,40 @@ async def partial_download(abspath, path, slice_=None):
 # mtime is in the key and unused in the body, so that a container rewritten
 # underneath is reopened instead of served from here (as get_filtered_array does)
 @functools.lru_cache(maxsize=16)
+def member_window(abspath, inner_key, mtime):
+    """Where a container leaf's frame lies in the file, as (offset, nbytes), or None.
+
+    A `.b2z` is a zip of *stored* members, so an external leaf's bytes in the
+    file are the Blosc2 frame it would have been written as on its own -- which
+    is what lets a ranged request be answered by seeking to it instead of
+    rebuilding the leaf.  None where there is no such window: a leaf embedded in
+    the store's own super-chunk, a `C2Array` reference, an HDF5 dataset (not a
+    Blosc2 frame at all), a CTable `.b2z` (not a store of leaves).
+
+    The frame's own magic is checked before the window is offered, so a `.b2z`
+    written by something else -- with compressed members, say -- cannot have a
+    window handed out that would decode to nonsense.
+    """
+    if abspath.suffix != ".b2z":
+        return None
+    try:
+        store = blosc2.open(abspath)
+    except Exception:
+        return None
+    if not isinstance(store, blosc2.DictStore):
+        return None
+    window = store.member_window(inner_key)
+    if window is None:
+        return None
+    offset, size = window
+    with open(abspath, "rb") as container:
+        container.seek(offset)
+        if container.read(10)[2:9] != b"b2frame":
+            return None
+    return window
+
+
+@functools.lru_cache(maxsize=16)
 def open_member(abspath, inner_key, mtime):
     """The leaf at *inner_key* inside a container file, kept between requests.
 
@@ -683,6 +717,7 @@ async def fetch_data(
             "use the download API if you only want to download the file"
         )
 
+    window = None  # where a container leaf's frame lies, when it has one
     filter = filter.strip() if filter else filter
     if filter:
         if field:
@@ -696,6 +731,11 @@ async def fetch_data(
             srv_utils.raise_bad_request(str(exc))
     elif inner_key is not None:
         # A member inside a container (e.g. a TreeStore .b2z or .h5 leaf).
+        # A leaf that is a whole frame inside the container can be served in
+        # ranges, by seeking to it -- what a stored dataset gets from
+        # FileResponse, and what lets a client read its blocks.  Not when a
+        # field is projected out of it: that is computed, not stored.
+        window = member_window(abspath, inner_key, abspath.stat().st_mtime)
         container = srv_utils.open_container_member(abspath, inner_key)
         if container is None:
             srv_utils.raise_not_found()
@@ -704,6 +744,19 @@ async def fetch_data(
 
     if field:
         container = container[field]
+
+    if isinstance(container, blosc2.DictStore):
+        # A container is a file of leaves rather than an array: its stored image
+        # is the file, which is what a client opening it as a store expects --
+        # and what the type ladder below used to die on, asking a TreeStore for
+        # a typesize it has not got (a 500 where the docstring promises the
+        # stored image).  Ranges come with FileResponse, so a leaf of it is
+        # reachable byte-wise too.
+        if slice_ is not None:
+            srv_utils.raise_bad_request(
+                f"{path} is a container, so there is nothing to slice; ask for a dataset inside it"
+            )
+        return FileResponse(abspath, filename=abspath.name, media_type="application/octet-stream")
 
     if isinstance(container, (blosc2.NDArray, blosc2.LazyArray, hdf5.HDF5Proxy, blosc2.NDField)):
         array = container
@@ -739,13 +792,20 @@ async def fetch_data(
         whole
         and (not isinstance(array, blosc2.LazyArray | hdf5.HDF5Proxy | blosc2.NDField | blosc2.CTable))
         and (not filter)
-        and inner_key is None  # abspath is the container, not this leaf: never stream it whole
     ):
-        # Send the data in the file straight to the client,
-        # avoiding slicing and re-compression.  This is also the one branch that
-        # serves byte ranges: FileResponse seeks into the file and sends only
-        # what was asked for, which is what block-granular clients read.
-        return FileResponse(abspath, filename=abspath.name, media_type="application/octet-stream")
+        if inner_key is None:
+            # Send the data in the file straight to the client,
+            # avoiding slicing and re-compression.  This is also the one branch that
+            # serves byte ranges: FileResponse seeks into the file and sends only
+            # what was asked for, which is what block-granular clients read.
+            return FileResponse(abspath, filename=abspath.name, media_type="application/octet-stream")
+        if window is not None and not field:
+            # The same for a leaf, whose frame lies inside the container: its
+            # stored image is a window of that file, ranges included.  Not only
+            # cheaper than the rebuild below -- more faithful, since the rebuild
+            # re-partitions (it slices and recompresses), and so disagrees with
+            # the chunks and blocks api/info reports for the very same leaf.
+            return srv_utils.window_response(abspath, window, range_header)
 
     # Everything below builds its answer, so a range cannot be honoured: say so
     # here, before computing a body that is not going to be sent

--- a/caterva2/services/server.py
+++ b/caterva2/services/server.py
@@ -497,6 +497,23 @@ async def partial_download(abspath, path, slice_=None):
         await proxy.afetch(slice_)
 
 
+# mtime is in the key and unused in the body, so that a container rewritten
+# underneath is reopened instead of served from here (as get_filtered_array does)
+@functools.lru_cache(maxsize=16)
+def open_member(abspath, inner_key, mtime):
+    """The leaf at *inner_key* inside a container file, kept between requests.
+
+    Reading a leaf chunk by chunk, which is what a proxy over one does, would
+    otherwise reopen the container for every chunk.  Holding on to the leaf is
+    safe: a TreeStore leaf is an independent object once fetched, and outlives
+    the adapter that produced it.
+    """
+    leaf = srv_utils.open_container_member(abspath, inner_key)
+    if leaf is None:  # no such key, or it names a group rather than a dataset
+        srv_utils.raise_not_found()
+    return leaf
+
+
 def get_abspath(
     path: pathlib.Path, user: (db.User | None), may_not_exist=False
 ) -> tuple[
@@ -850,17 +867,45 @@ async def get_chunk(
     nchunk: int,
     user: db.User = Depends(optional_user),
 ):
+    """One compressed chunk of a dataset, as it is stored.
+
+    This is how a client caches a remote array a chunk at a time, so it serves
+    what is *stored* in Blosc2 chunks and nothing else.  A container leaf counts:
+    a TreeStore keeps its leaves as ordinary Blosc2 arrays, and the chunk is
+    handed over as it lies in the ``.b2z``.  An HDF5 dataset and a CTable do not,
+    and say so rather than being taken apart and recompressed once per request --
+    ``api/fetch`` with a ``slice_`` computes exactly the region wanted for those,
+    which is both less work here and fewer bytes over the wire.
+    """
     if providers.provider_for(path.parts[0]) is not None:
         # Non-transitivity guard: peer roots are never re-exposed chunk-wise.
         raise fastapi.HTTPException(status_code=404, detail="external roots are non-transitive")
 
-    abspath = get_abspath(path, user)
-    lock = locks.setdefault(path, asyncio.Lock())
+    # Resolve the way api/fetch does, so a leaf inside a container is reachable:
+    # get_abspath alone drops the inner key and 404s on the container's own path
+    abspath, inner_key = split_and_resolve(path, user)
+    if abspath.suffix in srv_utils.HDF5_SUFFIXES:
+        srv_utils.raise_bad_request(
+            f"{path} is HDF5, whose chunks are HDF5-compressed rather than Blosc2 chunks; "
+            "fetch it with the slice_ parameter instead"
+        )
+    # One lock per container, so the leaves of a .b2z serialize with each other
+    # over the file they share; a plain dataset is its own container, as before
+    container_path = pathlib.Path(str(path)[: -len(inner_key)]) if inner_key else path
+    lock = locks.setdefault(container_path, asyncio.Lock())
     async with lock:
         root = path.parts[0]
         get_rootdir_or_error(root, user)
 
-        container = open_b2(abspath, path)
+        if inner_key is None:
+            container = open_b2(abspath, path)
+        else:
+            container = open_member(abspath, inner_key, abspath.stat().st_mtime)
+        if isinstance(container, blosc2.CTable):
+            srv_utils.raise_bad_request(
+                f"{path} is a CTable, which is a set of columns rather than one chunked array; "
+                "fetch it with the slice_ parameter instead"
+            )
         if isinstance(container, blosc2.LazyArray):
             # In case we do, this would have to be changed.
             chunk = container.get_chunk(nchunk)

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -15,6 +15,7 @@ import inspect
 import json
 import pathlib
 import random
+import secrets
 import string
 import types
 import typing
@@ -524,6 +525,9 @@ def raise_not_found(detail="Not Found"):
     raise fastapi.HTTPException(status_code=404, detail=detail)
 
 
+RANGES_OK = {"Accept-Ranges": "bytes"}
+"""Header for a response whose bytes can be seeked to, and so served in ranges."""
+
 NO_RANGES = {"Accept-Ranges": "none"}
 """Header for a response that is built as it is sent, and so cannot be seeked.
 
@@ -534,6 +538,133 @@ thing and ignores the `Range` header entirely, so a client that asks for 32
 bytes gets the whole body with a 200 and no way to notice.  This says which is
 which, and `refuse_range` makes the mistake cheap instead of silent.
 """
+
+
+def parse_ranges(range_header, size):
+    """The spans a ``Range: bytes=`` header names over *size* bytes.
+
+    Sorted, and the ones that touch merged, which is what Starlette does to the
+    ranges of a file response: a client sees one shape of answer whichever path
+    served it, and none of them can count on getting a part per span it asked
+    for.  An empty list means nothing it named is satisfiable (a 416); None
+    means it is not a byte range at all, which RFC 7233 says to ignore rather
+    than refuse.  Anything malformed raises ValueError.
+    """
+    units, _, spec = range_header.partition("=")
+    if units.strip().lower() != "bytes":
+        return None
+    spans = []
+    for part in spec.split(","):
+        first, sep, last = part.strip().partition("-")
+        if not sep:
+            raise ValueError(f"not a range: {part.strip()!r}")
+        if not first:  # bytes=-N: the last N bytes, which is how a suffix is asked for
+            wanted = int(last)
+            start, end = max(size - wanted, 0), size - 1
+            if wanted <= 0:
+                continue
+        else:
+            start = int(first)
+            end = min(int(last), size - 1) if last else size - 1
+        if start > end or start >= size:
+            continue  # unsatisfiable on its own: dropped, as RFC 7233 says
+        spans.append((start, end))
+    if not spans:
+        return spans
+    spans.sort()
+    merged = [spans[0]]
+    for start, end in spans[1:]:
+        if start <= merged[-1][1] + 1:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def ranged_window_response(abspath, window, range_header, media_type="application/octet-stream"):
+    """Answer *range_header* out of the ``(offset, size)`` *window* of *abspath*.
+
+    The window is a leaf's frame inside a container, so the coordinates are the
+    leaf's own: its byte 0 is the frame's first byte, and a range reaching past
+    its end is clamped to it.  Nothing outside the window a client named is ever
+    served through here, whatever it asks for.
+
+    None when the header is not a byte range at all, which leaves the caller to
+    answer as if it had not been sent.
+    """
+    offset, size = window
+    try:
+        spans = parse_ranges(range_header, size)
+    except ValueError:
+        raise_bad_request(f"malformed Range header: {range_header!r}")
+    if spans is None:
+        return None
+    if not spans:
+        raise fastapi.HTTPException(
+            status_code=416,
+            detail=f"none of {range_header!r} lies within the {size} bytes there are",
+            headers={**RANGES_OK, "Content-Range": f"bytes */{size}"},
+        )
+    with open(abspath, "rb") as frame:
+        if len(spans) == 1:
+            start, end = spans[0]
+            frame.seek(offset + start)
+            return fastapi.responses.Response(
+                frame.read(end - start + 1),
+                status_code=206,
+                media_type=media_type,
+                headers={**RANGES_OK, "Content-Range": f"bytes {start}-{end}/{size}"},
+            )
+        # Several at once, which is one round trip instead of one each: RFC 7233
+        # carries them as a multipart body, each part saying which bytes it holds
+        boundary = secrets.token_hex(16)
+        body = bytearray()
+        for start, end in spans:
+            frame.seek(offset + start)
+            body += (
+                f"--{boundary}\r\nContent-Type: {media_type}\r\n"
+                f"Content-Range: bytes {start}-{end}/{size}\r\n\r\n"
+            ).encode()
+            body += frame.read(end - start + 1) + b"\r\n"
+        body += f"--{boundary}--\r\n".encode()
+    return fastapi.responses.Response(
+        bytes(body),
+        status_code=206,
+        media_type=f"multipart/byteranges; boundary={boundary}",
+        headers=RANGES_OK,
+    )
+
+
+def window_response(abspath, window, range_header=None):
+    """The stored image of a container leaf, out of the *window* of *abspath*.
+
+    What `FileResponse` is for a dataset with a file of its own, for one that
+    lives inside a container: the whole of its frame, or the ranges of it a
+    client asked for.  Streamed rather than read whole, since a leaf can be as
+    large as any dataset.
+    """
+    if range_header:
+        ranged = ranged_window_response(abspath, window, range_header)
+        if ranged is not None:  # None: not a byte range, so answer as if unasked
+            return ranged
+    offset, size = window
+
+    def stream():
+        with open(abspath, "rb") as container:
+            container.seek(offset)
+            left = size
+            while left > 0:
+                data = container.read(min(left, 2**20))
+                if not data:
+                    break
+                left -= len(data)
+                yield data
+
+    return fastapi.responses.StreamingResponse(
+        stream(),
+        media_type="application/octet-stream",
+        headers={**RANGES_OK, "Content-Length": str(size)},
+    )
 
 
 def refuse_range(range_header, path):

--- a/caterva2/services/srv_utils.py
+++ b/caterva2/services/srv_utils.py
@@ -524,6 +524,31 @@ def raise_not_found(detail="Not Found"):
     raise fastapi.HTTPException(status_code=404, detail=detail)
 
 
+NO_RANGES = {"Accept-Ranges": "none"}
+"""Header for a response that is built as it is sent, and so cannot be seeked.
+
+A dataset served straight from a file gets byte ranges for free -- Starlette's
+`FileResponse` implements RFC 7233 by itself -- and a client can then read the
+blocks of a slice instead of whole chunks.  A `StreamingResponse` has no such
+thing and ignores the `Range` header entirely, so a client that asks for 32
+bytes gets the whole body with a 200 and no way to notice.  This says which is
+which, and `refuse_range` makes the mistake cheap instead of silent.
+"""
+
+
+def refuse_range(range_header, path):
+    """416 a ranged request for something that is computed rather than stored."""
+    if range_header:
+        raise fastapi.HTTPException(
+            status_code=416,
+            detail=(
+                f"{path} is not served from a file (it is computed, filtered or held "
+                "inside a container), so byte ranges are not available for it"
+            ),
+            headers=NO_RANGES,
+        )
+
+
 #
 # Blosc2 related helpers
 #

--- a/caterva2/tests/test_hdf5_tree.py
+++ b/caterva2/tests/test_hdf5_tree.py
@@ -329,3 +329,17 @@ def test_web_bogus_h5_no_500(client):
     # Mounting it as a virtual root just lists nothing, no crash.
     r = httpx.get(f"{base}/htmx/path-list/", params={"roots": [f"{root.name}/bogus.h5"]})
     assert r.status_code == 200
+
+
+# --- api/chunk on an HDF5 leaf ---------------------------------------------
+
+
+def test_chunk_of_an_hdf5_leaf_is_refused(fill_h5_public, client):
+    """An HDF5 dataset is HDF5-compressed, so a Blosc2 chunk of one would have to
+    be read and recompressed per request. The endpoint says so instead, and
+    api/fetch with a slice_ computes exactly the region wanted."""
+    fname, _root = fill_h5_public
+    for path in (f"{fname}/g/a", fname):  # a leaf, and the file itself
+        response = httpx.get(f"{client.urlbase}/api/chunk/{TEST_CATERVA2_ROOT}/{path}?nchunk=0")
+        assert response.status_code == 400
+        assert "slice_" in response.json()["detail"]

--- a/caterva2/tests/test_ranges.py
+++ b/caterva2/tests/test_ranges.py
@@ -1,0 +1,121 @@
+###############################################################################
+# Caterva2 - On demand access to remote Blosc2 data repositories
+#
+# Copyright (c) 2023 ironArray SLU <contact@ironarray.io>
+# https://www.blosc.org
+# License: GNU Affero General Public License v3.0
+# See LICENSE.txt for details about copyright and rights to use.
+###############################################################################
+"""Byte ranges over `api/fetch`.
+
+A stored dataset is served with a `FileResponse`, which implements RFC 7233 by
+itself: a client can read the header, the chunk offsets and single blocks of the
+frame instead of transferring it whole, which is what blosc2's `Proxy` over a
+`C2Array` does.  Nothing else asserted that, so a refactor turning that one
+`return` into a `StreamingResponse` would silently halve every such client's
+performance -- hence the first test here.
+
+Everything else is built as it is sent and cannot honour a range at all.  The
+rest of the tests are that it says so, instead of answering a request for 32
+bytes with the whole body and a 200.
+"""
+
+import pathlib
+
+import blosc2
+import httpx
+import numpy as np
+import pytest
+
+from .services import TEST_CATERVA2_ROOT, TEST_STATE_DIR
+
+DATASET = "ds-1d.b2nd"
+
+
+@pytest.fixture(scope="module")
+def public_dataset(client, examples_dir):
+    """One stored dataset in the public area, which is what serves ranges."""
+    dest = pathlib.Path(TEST_STATE_DIR) / "server/public" / DATASET
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes((examples_dir / DATASET).read_bytes())
+    return DATASET
+
+
+def _url(client, path):
+    return f"{client.urlbase}/api/fetch/{TEST_CATERVA2_ROOT}/{path}"
+
+
+def test_stored_dataset_serves_ranges(client, public_dataset):
+    response = httpx.get(_url(client, public_dataset), headers={"Range": "bytes=0-31"})
+    assert response.status_code == 206
+    assert response.headers["accept-ranges"] == "bytes"
+    total = int(response.headers["content-range"].split("/")[1])
+    assert response.headers["content-range"] == f"bytes 0-31/{total}"
+    assert len(response.content) == 32
+    assert response.content[2:10] == b"b2frame\x00"  # the frame magic, as read from the file
+
+    # ... and the whole of it is still the whole of it
+    whole = httpx.get(_url(client, public_dataset))
+    assert whole.status_code == 200
+    assert len(whole.content) == total
+    assert whole.content[:32] == response.content
+
+
+def test_ranges_reach_into_the_frame(client, public_dataset):
+    # Not just the first bytes: a block client reads at an offset, and gets the
+    # bytes at that offset rather than a body that starts from zero
+    whole = httpx.get(_url(client, public_dataset)).content
+    response = httpx.get(_url(client, public_dataset), headers={"Range": "bytes=100-163"})
+    assert response.status_code == 206
+    assert response.content == whole[100:164]
+
+
+def test_a_slice_refuses_ranges(client, public_dataset):
+    # A slice is built and re-compressed per request, so there is no file to
+    # seek into; before, this answered with the whole slice and a 200
+    response = httpx.get(
+        _url(client, public_dataset), params={"slice_": "0:10"}, headers={"Range": "bytes=0-31"}
+    )
+    assert response.status_code == 416
+    assert response.headers["accept-ranges"] == "none"
+    assert not response.content.startswith(b"\x00b2")
+
+
+def test_a_lazy_expression_refuses_ranges(auth_client, public_dataset):
+    # The case the discriminator on the client side is built around: this one is
+    # computed per request, so there are no stored bytes to seek into at all
+    if not auth_client:
+        pytest.skip("authentication support needed")
+    operand = auth_client.get(f"{TEST_CATERVA2_ROOT}/{public_dataset}")
+    expression = auth_client.upload(operand + 0, "@personal/rangeexpr.b2nd")
+    url = f"{auth_client.urlbase}/api/fetch/{expression.path}"
+    headers = {"Cookie": auth_client.cookie}
+
+    response = httpx.get(url, headers={**headers, "Range": "bytes=0-31"})
+    assert response.status_code == 416
+    assert response.headers["accept-ranges"] == "none"
+
+    # ... and it still fetches whole, as it always did
+    whole = httpx.get(url, headers=headers)
+    assert whole.status_code == 200
+    assert whole.headers["accept-ranges"] == "none"
+    np.testing.assert_array_equal(blosc2.ndarray_from_cframe(whole.content)[:], operand[:])
+
+
+def test_a_streamed_response_says_it_serves_no_ranges(client, public_dataset):
+    # No Range header at all: the answer still carries the fact, so a client can
+    # tell without asking for bytes it may not get
+    response = httpx.get(_url(client, public_dataset), params={"slice_": "0:10"})
+    assert response.status_code == 200
+    assert response.headers["accept-ranges"] == "none"
+
+
+def test_download_refuses_ranges(client, public_dataset):
+    url = f"{client.urlbase}/api/download/{TEST_CATERVA2_ROOT}/{public_dataset}"
+    response = httpx.get(url, headers={"Range": "bytes=0-31"})
+    assert response.status_code == 416
+    assert response.headers["accept-ranges"] == "none"
+
+    whole = httpx.get(url)
+    assert whole.status_code == 200
+    assert whole.headers["accept-ranges"] == "none"

--- a/caterva2/tests/test_treestore.py
+++ b/caterva2/tests/test_treestore.py
@@ -372,3 +372,112 @@ def test_the_opened_leaf_is_kept_between_requests(fill_tree_public):
     assert open_member(abspath, "/g/a", mtime) is leaf
     assert open_member(abspath, "/g/b", mtime) is not leaf
     assert open_member(abspath, "/g/a", mtime + 1) is not leaf  # rewritten since
+
+
+# --- byte ranges into a leaf's frame ----------------------------------------
+
+
+def _fetch_url(client, path):
+    return f"{client.urlbase}/api/fetch/{TEST_CATERVA2_ROOT}/{path}"
+
+
+def _window(path, key):
+    store = blosc2.open(str(path))
+    return store.member_window(key)
+
+
+def test_a_leaf_is_served_from_its_window(fill_tree_public, client):
+    """A .b2z keeps each leaf as a stored zip member, so the leaf's frame is in
+    the file and the whole of it can be served by seeking to it."""
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    offset, nbytes = _window(abspath, "/g/a")
+
+    response = httpx.get(_fetch_url(client, f"{fname}/g/a"))
+    assert response.status_code == 200
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.content == abspath.read_bytes()[offset : offset + nbytes]
+    assert np.array_equal(
+        blosc2.ndarray_from_cframe(response.content)[:], np.arange(6, dtype="i4").reshape(2, 3)
+    )
+
+
+def test_a_leaf_keeps_the_partitioning_info_reports(fill_tree_public, client):
+    """The rebuild this replaced re-sliced and recompressed, so what came back
+    disagreed with the chunks and blocks api/info reports for the same leaf."""
+    fname, _root = fill_tree_public
+    dest = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    with blosc2.TreeStore(str(dest), mode="a") as tstore:
+        tstore["/chunked"] = blosc2.asarray(
+            np.arange(4000, dtype="i4").reshape(200, 20), chunks=(50, 20), blocks=(10, 20)
+        )
+
+    fetched = blosc2.ndarray_from_cframe(httpx.get(_fetch_url(client, f"{fname}/chunked")).content)
+    info = httpx.get(f"{client.urlbase}/api/info/{TEST_CATERVA2_ROOT}/{fname}/chunked").json()
+    assert fetched.chunks == tuple(info["chunks"]) == (50, 20)
+    assert fetched.blocks == tuple(info["blocks"]) == (10, 20)
+
+
+def test_ranges_of_a_leaf(fill_tree_public, client):
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    offset, nbytes = _window(abspath, "/g/a")
+    raw = abspath.read_bytes()
+
+    response = httpx.get(_fetch_url(client, f"{fname}/g/a"), headers={"Range": "bytes=0-31"})
+    assert response.status_code == 206
+    assert response.headers["content-range"] == f"bytes 0-31/{nbytes}"
+    assert response.content == raw[offset : offset + 32]
+    # ... and the leaf's byte 0 is the frame's, not the container's
+    assert response.content[2:9] == b"b2frame"
+
+
+def test_a_range_cannot_reach_past_the_leaf(fill_tree_public, client):
+    # The window is the whole of what this path is about: a range that would
+    # run into the next member is clamped, and one that starts beyond it is a 416
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    _offset, nbytes = _window(abspath, "/g/a")
+
+    clamped = httpx.get(_fetch_url(client, f"{fname}/g/a"), headers={"Range": f"bytes=0-{nbytes + 999}"})
+    assert clamped.status_code == 206
+    assert clamped.headers["content-range"] == f"bytes 0-{nbytes - 1}/{nbytes}"
+    assert len(clamped.content) == nbytes
+
+    beyond = httpx.get(_fetch_url(client, f"{fname}/g/a"), headers={"Range": f"bytes={nbytes}-{nbytes + 9}"})
+    assert beyond.status_code == 416
+    assert beyond.headers["content-range"] == f"bytes */{nbytes}"
+
+
+def test_several_ranges_of_a_leaf_come_back_multipart(fill_tree_public, client):
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    offset, _nbytes = _window(abspath, "/g/a")
+    raw = abspath.read_bytes()
+
+    response = httpx.get(_fetch_url(client, f"{fname}/g/a"), headers={"Range": "bytes=0-15, 40-55"})
+    assert response.status_code == 206
+    assert response.headers["content-type"].startswith("multipart/byteranges")
+    assert raw[offset : offset + 16] in response.content
+    assert raw[offset + 40 : offset + 56] in response.content
+
+
+def test_a_sliced_leaf_still_refuses_ranges(fill_tree_public, client):
+    # A slice is computed per request whatever it is a slice of
+    fname, _root = fill_tree_public
+    response = httpx.get(
+        _fetch_url(client, f"{fname}/h/c"), params={"slice_": "2:5"}, headers={"Range": "bytes=0-31"}
+    )
+    assert response.status_code == 416
+
+
+def test_a_container_is_served_whole(fill_tree_public, client):
+    """A container is a file of leaves rather than an array; asking for it used
+    to die in the type ladder, on a typesize a TreeStore has not got."""
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+
+    response = httpx.get(_fetch_url(client, fname))
+    assert response.status_code == 200
+    assert response.content == abspath.read_bytes()
+    assert httpx.get(_fetch_url(client, fname), params={"slice_": "0:2"}).status_code == 400

--- a/caterva2/tests/test_treestore.py
+++ b/caterva2/tests/test_treestore.py
@@ -308,3 +308,67 @@ def test_htmx_path_view_member_0d_scalar(fill_tree_public, client):
     resp = httpx.post(f"{base}/htmx/path-view/{root.name}/{fname}/s/scalar")
     assert resp.status_code == 200
     assert "42" in resp.text
+
+
+# --- api/chunk on a container leaf -----------------------------------------
+
+
+def _chunk_url(client, path, nchunk):
+    return f"{client.urlbase}/api/chunk/{TEST_CATERVA2_ROOT}/{path}?nchunk={nchunk}"
+
+
+def test_chunk_of_a_leaf_is_the_stored_one(fill_tree_public, client):
+    """A TreeStore keeps its leaves as ordinary Blosc2 arrays, so a chunk of one
+    is served as it lies in the .b2z -- nothing is sliced or recompressed."""
+    fname, _root = fill_tree_public
+    response = httpx.get(_chunk_url(client, f"{fname}/g/a", 0))
+    assert response.status_code == 200
+
+    stored = blosc2.open(pathlib.Path(TEST_STATE_DIR) / "server/public" / fname)["/g/a"]
+    assert response.content == stored.schunk.get_chunk(0)
+
+
+def test_proxy_over_a_leaf_reads_it(fill_tree_public, client):
+    """What the chunk endpoint is for: a Proxy caching a remote array chunk by
+    chunk. Before api/chunk resolved container paths, this 404ed."""
+    fname, _root = fill_tree_public
+    remote = blosc2.C2Array(f"{TEST_CATERVA2_ROOT}/{fname}/g/a", urlbase=client.urlbase)
+    proxy = blosc2.Proxy(remote, mode="w")
+    assert np.array_equal(proxy[:], np.arange(6, dtype="i4").reshape(2, 3))
+
+
+def test_chunk_of_a_missing_leaf(fill_tree_public, client):
+    fname, _root = fill_tree_public
+    assert httpx.get(_chunk_url(client, f"{fname}/g/nope", 0)).status_code == 404
+    # A group is not a dataset either
+    assert httpx.get(_chunk_url(client, f"{fname}/g", 0)).status_code == 404
+
+
+def test_chunk_of_a_ctable_is_refused(client):
+    """A CTable is a set of columns rather than one chunked array: it has no
+    schunk to take a chunk out of, and used to fail as a 500."""
+    from .test_ctable import _make_table
+
+    fname = "test_chunk_ctable.b2z"
+    dest = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _make_table(dest)
+
+    response = httpx.get(_chunk_url(client, fname, 0))
+    assert response.status_code == 400
+    assert "slice_" in response.json()["detail"]
+
+
+def test_the_opened_leaf_is_kept_between_requests(fill_tree_public):
+    """Reading a leaf chunk by chunk must not reopen the container per chunk;
+    a container rewritten underneath must not be served from the cache either."""
+    from caterva2.services.server import open_member
+
+    fname, _root = fill_tree_public
+    abspath = pathlib.Path(TEST_STATE_DIR) / "server/public" / fname
+    mtime = abspath.stat().st_mtime
+
+    leaf = open_member(abspath, "/g/a", mtime)
+    assert open_member(abspath, "/g/a", mtime) is leaf
+    assert open_member(abspath, "/g/b", mtime) is not leaf
+    assert open_member(abspath, "/g/a", mtime + 1) is not leaf  # rewritten since


### PR DESCRIPTION
Two things, both about bytes a client can ask for by range.

Companion client-side PR: **Blosc/python-blosc2#702**, whose
`plans/cat2-block-granularity.md` and `plans/container-leaf-ranges.md` carry the
analysis and the measurements.

Based on `c2cache-monorepo`.

## Say which responses serve byte ranges, and refuse the rest

A stored dataset is served with a `FileResponse`, which implements RFC 7233 by
itself — that is what lets a blosc2 `Proxy` over a `C2Array` read the blocks a
slice touches instead of whole chunks. Everything else here builds its answer as
it sends it (a slice, a filtered query, a lazy expression, an HDF5 leaf, a peer
dataset), and a `StreamingResponse` has no range support at all: those answered
a request for 32 bytes with the whole body and a 200, which no client could
notice. Measured: fsspec's HTTP filesystem, asked for 32 bytes of a sliced
fetch, returned 1,364,328 of them in 2.7 s and reported no error.

Those paths now carry `Accept-Ranges: none` and answer a `Range` header with a
416, before computing a body that is not going to be sent — after the path is
resolved, so a path that does not exist is still a 404. The tests also pin the
`FileResponse` branch itself, which nothing asserted: a refactor turning that one
`return` into a `StreamingResponse` would silently halve every block client.

## Serve container leaves: their chunks, and their ranges

- **`api/chunk` resolves container paths**, which it never did: it was the last
  read endpoint using `get_abspath` rather than `split_and_resolve`, so a
  `Proxy` over a `.b2z` leaf could not fetch anything at all. HDF5 datasets and
  CTables are refused with a 400 naming `slice_` rather than being recompressed
  per request, and the opened leaf is cached (keyed on the container's mtime, as
  `get_filtered_array` is).
- **`api/fetch` serves a leaf from its window in the file.** A `.b2z` is a zip of
  *stored* members, so a leaf's bytes are the frame it would have been written
  as on its own; blosc2's new `DictStore.member_window` says where. The whole
  leaf, or the ranges of it a client asks for — clamped to the leaf, so nothing
  outside the window it named is ever served. No client change was needed: a
  proxy over a leaf probes with a `Range` as it does for any dataset and reads
  blocks. **2.8x on a point read, 20x fewer bytes**, and the same table as a
  plain `.b2nd` row for row.
- The whole-leaf answer is the window too, which is not only cheaper than the
  rebuild it replaces (0.034 s -> 0.016 s for 27 MB) but **more faithful**: the
  rebuild sliced and recompressed, so a leaf stored with `chunks=(1, 1000, 500)`
  came back as `(4, 1000, 500)` while `api/info` kept reporting the stored ones.
  They agree now because they are the same bytes.
- **Fetching a container whole is a 200 rather than a 500.** A `TreeStore` fell
  through `fetch_data`'s type ladder into the `SChunk` branch and died on a
  `typesize` it has not got, where the docstring promises the stored image.

## Tests

359 pass; the two `test_peers.py` failures are pre-existing on the base branch
(verified by stashing). New coverage: 206 with `Content-Range` on a stored
`.b2nd`, the 416s and their `Accept-Ranges: none`, a leaf's window byte for byte,
clamped and out-of-range requests, multipart, a leaf's partitioning matching
`api/info`, chunks of a leaf byte-identical to the stored ones, and the HDF5 and
CTable refusals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
